### PR TITLE
Remove dependency on Bunyan

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -26,12 +26,24 @@ client is:
 |---------------|-----------------------------------------------------------|
 |url            |A valid LDAP URL (proto/host/port only)                    |
 |socketPath     |Socket path if using AF\_UNIX sockets                      |
-|log            |Bunyan logger instance (Default: built-in instance)        |
+|log            |A compatible logger instance (Default: no-op logger)       |
 |timeout        |Milliseconds client should let operations live for before timing out (Default: Infinity)|
 |connectTimeout |Milliseconds client should wait before timing out on TCP connections (Default: OS default)|
 |tlsOptions     |Additional options passed to TLS connection layer when connecting via `ldaps://` (See: The TLS docs for node.js)|
 |idleTimeout    |Milliseconds after last activity before client emits idle event|
 |strictDN       |Force strict DN parsing for client methods (Default is true)|
+
+### Note On Logger
+
+A passed in logger is expected to conform to the [Bunyan](https://www.npmjs.com/package/bunyan)
+API. Specifically, the logger is expected to have a `child()` method. If a logger
+is supplied that does not have such a method, then a shim version is added
+that merely returns the passed in logger.
+
+Known compatible loggers are:
+
++ [Bunyan](https://www.npmjs.com/package/bunyan)
++ [Pino](https://www.npmjs.com/package/pino)
 
 ## Connection management
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -16,9 +16,21 @@ The code to create a new server looks like:
 
 The full list of options is:
 
-||log||You can optionally pass in a bunyan instance the client will use to acquire a logger.||
+||log||You can optionally pass in a Bunyan compatible logger instance the client will use to acquire a child logger.||
 ||certificate||A PEM-encoded X.509 certificate; will cause this server to run in TLS mode.||
 ||key||A PEM-encoded private key that corresponds to _certificate_ for SSL.||
+
+### Note On Logger
+
+The passed in logger is expected to conform to the Log4j standard API.
+Internally, [abstract-logging](https://www.npmjs.com/packages/abstract-logging) is
+used to implement the interface. As a result, no log messages will be generated
+unless an external logger is supplied.
+
+Known compatible loggers are:
+
++ [Bunyan](https://www.npmjs.com/package/bunyan)
++ [Pino](https://www.npmjs.com/package/pino)
 
 ## Properties on the server object
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,8 +1,6 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
-var assert = require('assert');
-
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 
 var Client = require('./client');
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -2,19 +2,10 @@
 
 var assert = require('assert');
 
-var Logger = require('bunyan');
+var logger = require('abstract-logging');
 
 var Client = require('./client');
 
-
-///--- Globals
-
-var DEF_LOG = new Logger({
-  name: 'ldapjs',
-  component: 'client',
-  stream: process.stderr,
-  serializers: Logger.stdSerializers
-});
 
 
 ///--- Functions
@@ -47,7 +38,9 @@ module.exports = {
     if (!xor(options.url, options.socketPath))
       throw new TypeError('options.url ^ options.socketPath (String) required');
     if (!options.log)
-      options.log = DEF_LOG;
+      options.log = logger;
+    if (!options.log.child)
+      options.log.child = function () { return options.log; }
     if (typeof (options.log) !== 'object')
       throw new TypeError('options.log must be an object');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var Logger = require('bunyan');
+var logger = require('abstract-logging');
 
 var client = require('./client');
 var Attribute = require('./attribute');
@@ -33,11 +33,7 @@ module.exports = {
       throw new TypeError('options (object) required');
 
     if (!options.log) {
-      options.log = new Logger({
-        name: 'ldapjs',
-        component: 'client',
-        stream: process.stderr
-      });
+      options.log = logger;
     }
 
     return new Server(options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 
 var client = require('./client');
 var Attribute = require('./attribute');
@@ -8,7 +8,6 @@ var Change = require('./change');
 var Protocol = require('./protocol');
 var Server = require('./server');
 
-var assert = require('assert');
 var controls = require('./controls');
 var persistentSearch = require('./persistent_search');
 var dn = require('./dn');

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "node": ">=0.10"
   },
   "dependencies": {
+    "abstract-logging": "^1.0.0",
     "asn1": "0.2.3",
     "assert-plus": "^1.0.0",
-    "bunyan": "^1.8.3",
-    "dashdash": "^1.14.0",
     "backoff": "^2.5.0",
     "ldap-filter": "^0.2.2",
+    "dashdash": "^1.14.0",
     "once": "^1.4.0",
     "vasync": "^1.6.4",
     "verror": "^1.8.1"
@@ -49,7 +49,7 @@
     "tape": "^4.6.2"
   },
   "scripts": {
-        "report": "./node_modules/.bin/istanbul report html && open ./coverage/lcov-report/index.html",
-        "test": "./node_modules/.bin/istanbul cover --print none test/test.js | ./node_modules/.bin/faucet"
+    "report": "./node_modules/.bin/istanbul report html && open ./coverage/lcov-report/index.html",
+    "test": "./node_modules/.bin/istanbul cover --print none test/test.js | ./node_modules/.bin/faucet"
   }
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var Logger = require('bunyan');
+var logger = require('abstract-logging');
 
 var test = require('tape').test;
 var uuid = require('node-uuid');
@@ -15,14 +15,6 @@ var BIND_PW = 'secret';
 var SOCKET = '/tmp/.' + uuid();
 
 var SUFFIX = 'dc=test';
-
-var LOG = new Logger({
-  name: 'ldapjs_unit_test',
-  stream: process.stderr,
-  level: (process.env.LOG_LEVEL || 'info'),
-  serializers: Logger.stdSerializers,
-  src: true
-});
 
 var ldap;
 var Attribute;
@@ -288,7 +280,7 @@ test('setup', function (t) {
     client = ldap.createClient({
       connectTimeout: parseInt(process.env.LDAP_CONNECT_TIMEOUT || 0, 10),
       socketPath: SOCKET,
-      log: LOG
+      log: logger
     });
     t.ok(client);
     t.end();
@@ -338,7 +330,7 @@ test('auto-bind bad credentials', function (t) {
     socketPath: SOCKET,
     bindDN: BIND_DN,
     bindCredentials: 'totallybogus',
-    log: LOG
+    log: logger
   });
   clt.once('error', function (err) {
     t.equal(err.code, ldap.LDAP_INVALID_CREDENTIALS);
@@ -353,7 +345,7 @@ test('auto-bind success', function (t) {
     socketPath: SOCKET,
     bindDN: BIND_DN,
     bindCredentials: BIND_PW,
-    log: LOG
+    log: logger
   });
   clt.once('connect', function () {
     t.ok(clt);
@@ -978,7 +970,7 @@ test('setup action', function (t) {
   var setupClient = ldap.createClient({
       connectTimeout: parseInt(process.env.LDAP_CONNECT_TIMEOUT || 0, 10),
       socketPath: SOCKET,
-      log: LOG
+      log: logger
     });
   setupClient.on('setup', function (clt, cb) {
     clt.bind(BIND_DN, BIND_PW, function (err, res) {
@@ -1002,7 +994,7 @@ test('setup reconnect', function (t) {
       connectTimeout: parseInt(process.env.LDAP_CONNECT_TIMEOUT || 0, 10),
       socketPath: SOCKET,
       reconnect: true,
-      log: LOG
+      log: logger
     });
   rClient.on('setup', function (clt, cb) {
     clt.bind(BIND_DN, BIND_PW, function (err, res) {
@@ -1059,7 +1051,7 @@ test('setup abort', function (t) {
       connectTimeout: parseInt(process.env.LDAP_CONNECT_TIMEOUT || 0, 10),
       socketPath: SOCKET,
       reconnect: true,
-      log: LOG
+      log: logger
     });
   var message = 'It\'s a trap!';
   setupClient.on('setup', function (clt, cb) {
@@ -1081,7 +1073,7 @@ test('abort reconnect', function (t) {
     connectTimeout: parseInt(process.env.LDAP_CONNECT_TIMEOUT || 0, 10),
     socketPath: '/dev/null',
     reconnect: true,
-    log: LOG
+    log: logger
   });
   var retryCount = 0;
   abortClient.on('connectError', function () {
@@ -1109,7 +1101,7 @@ test('reconnect max retries', function (t) {
       initialDelay: 10,
       maxDelay: 100
     },
-    log: LOG
+    log: logger
   });
   var count = 0;
   rClient.on('connectError', function () {
@@ -1127,7 +1119,7 @@ test('reconnect on server close', function (t) {
   var clt = ldap.createClient({
     socketPath: SOCKET,
     reconnect: true,
-    log: LOG
+    log: logger
   });
   clt.on('setup', function (sclt, cb) {
     sclt.bind(BIND_DN, BIND_PW, function (err, res) {
@@ -1153,7 +1145,7 @@ test('no auto-reconnect on unbind', function (t) {
   var clt = ldap.createClient({
     socketPath: SOCKET,
     reconnect: true,
-    log: LOG
+    log: logger
   });
   clt.on('setup', function (sclt, cb) {
     sclt.bind(BIND_DN, BIND_PW, function (err, res) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 
 var test = require('tape').test;
 var uuid = require('node-uuid');

--- a/test/messages/del_request.test.js
+++ b/test/messages/del_request.test.js
@@ -2,7 +2,7 @@
 
 
 var asn1 = require('asn1');
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 var test = require('tape').test;
 
 

--- a/test/messages/del_request.test.js
+++ b/test/messages/del_request.test.js
@@ -2,7 +2,7 @@
 
 
 var asn1 = require('asn1');
-var Logger = require('bunyan');
+var logger = require('abstract-logging');
 var test = require('tape').test;
 
 
@@ -45,7 +45,7 @@ test('parse', function (t) {
   ber.writeString('cn=test', 0x4a);
 
   var req = new DeleteRequest({
-    log: new Logger({name: 'del_request.test.js'})
+    log: logger
   });
   var reader = new BerReader(ber.buffer);
   reader.readSequence(0x4a);

--- a/test/messages/parser.test.js
+++ b/test/messages/parser.test.js
@@ -1,13 +1,12 @@
 // Copyright 2014 Joyent, Inc.  All rights reserved.
 
 var test = require('tape').test;
-var bunyan = require('bunyan');
+var logger = require('abstract-logging');
 
 ///--- Globals
 
 var lib;
 var Parser;
-var LOG = bunyan.createLogger({name: 'ldapjs-test'});
 
 ///--- Tests
 test('load library', function (t) {
@@ -19,7 +18,7 @@ test('load library', function (t) {
 });
 
 test('wrong protocol error', function (t) {
-  var p = new Parser({log: LOG});
+  var p = new Parser({log: logger});
 
   p.once('error', function (err) {
     t.ok(err);
@@ -31,7 +30,7 @@ test('wrong protocol error', function (t) {
 });
 
 test('bad protocol op', function (t) {
-  var p = new Parser({log: LOG});
+  var p = new Parser({log: logger});
   var message = new lib.LDAPMessage({
     protocolOp: 254 // bogus (at least today)
   });
@@ -44,7 +43,7 @@ test('bad protocol op', function (t) {
 });
 
 test('bad message structure', function (t) {
-  var p = new Parser({log: LOG});
+  var p = new Parser({log: logger});
 
   // message with bogus structure
   var message = new lib.LDAPMessage({

--- a/test/messages/parser.test.js
+++ b/test/messages/parser.test.js
@@ -1,7 +1,7 @@
 // Copyright 2014 Joyent, Inc.  All rights reserved.
 
 var test = require('tape').test;
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 
 ///--- Globals
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var logger = require('abstract-logging');
+var logger = Object.create(require('abstract-logging'));
 
 var test = require('tape').test;
 var uuid = require('node-uuid');

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,6 @@
 // Copyright 2011 Mark Cavage, Inc.  All rights reserved.
 
-var Logger = require('bunyan');
+var logger = require('abstract-logging');
 
 var test = require('tape').test;
 var uuid = require('node-uuid');


### PR DESCRIPTION
This PR removes the explicit dependency on Bunyan. It replaces the internal usage of Bunyan with a no operation logger, `abstract-logging`. This removes the overhead introduced by Bunyan when an external logger is not supplied. Bunyan is not a fast logger, and thus slows down the `ldapjs` library unnecessarily (see https://github.com/pinojs/pino#benchmarks).

The documentation is also updated with some detail on what is required of a passed in logger and points out a couple compatible loggers.