### PR TITLE
destroy socket if auto-bind fails

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -348,6 +348,9 @@ function Client(options) {
     this.on('setup', function (clt, cb) {
       clt.bind(options.bindDN, options.bindCredentials, function (err) {
         if (err) {
+          if (self._socket) {
+            self._socket.destroy()
+          }
           self.emit('error', err);
         }
         cb(err);

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -334,6 +334,7 @@ test('auto-bind bad credentials', function (t) {
   });
   clt.once('error', function (err) {
     t.equal(err.code, ldap.LDAP_INVALID_CREDENTIALS);
+    t.ok(clt._socket.destroyed, 'expect socket to be destroyed');
     clt.destroy();
     t.end();
   });


### PR DESCRIPTION
With a client, when using bindDN and bindCredentials, if the credentials are bad then the bind fails as expected -- but the socket is left open. An explicit call to `client.destroy()` is required in order to release the socket. This is confusing since the socket would be closed after a successful operation. Closing the socket upon bind failure makes it consistent.

Also, the bind error was being reported twice. Once as an emit, and again in the callback. Because a bind failure ends with the callback being executed, an emit doesn't make sense.

The test that applies to this behavior is *auto-bind bad credentials* in `test/client.test.js` -- it continues to pass with the changes I've made, but because it calls `clt.destroy()` explicitly, it doesn't replicate the problems I was having.