### PR TITLE
Raise the correct event name

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1406,7 +1406,7 @@ Client.prototype._sendSocket = function _sendSocket(message,
       return sendResult('end', null);
 
     if (msg instanceof SearchEntry || msg instanceof SearchReference) {
-      var event = msg.constructor.name;
+      var event = msg.type;
       event = event[0].toLowerCase() + event.slice(1);
       return sendResult(event, msg);
     } else {


### PR DESCRIPTION
This PR is in response to the issue #406 which fixes the event name for uglyfied code.

All tests returned green ✅