### PR TITLE
Check for null or undefined values

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -427,15 +427,17 @@ Client.prototype.add = function add(name, entry, controls, callback) {
 
     entry = [];
     Object.keys(save).forEach(function (k) {
-      var attr = new Attribute({type: k});
-      if (Array.isArray(save[k])) {
-        save[k].forEach(function (v) {
-          attr.addValue(v.toString());
-        });
-      } else {
-        attr.addValue(save[k].toString());
+      if (save[k]) {
+        var attr = new Attribute({ type: k });
+        if (Array.isArray(save[k])) {
+          save[k].forEach(function (v) {
+            attr.addValue(v.toString());
+          });
+        } else {
+          attr.addValue(save[k].toString());
+        }
+        entry.push(attr);
       }
-      entry.push(attr);
     });
   }
 


### PR DESCRIPTION
Sometimes you have a fix mapping where you have to add empty values. For example
```
"sn": "Mustermann",
"givenName: "Max",
"l": [null_or_undefined_or""]
```
Currently this is not possible. This change just check if value is not null or undefined,... .