### PR TITLE
Adding patch for ldaps concurrent failures.

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1473,12 +1473,14 @@ Client.prototype._sendSocket = function _sendSocket(message,
     log.trace('sending request %j', message.json);
 
   try {
-    return conn.write(message.toBer(), writeCallback);
+    writeCallback();
+    return conn.write(message.toBer());
   } catch (e) {
     if (timer)
       clearTimeout(timer);
 
     log.trace({err: e}, 'Error writing message to socket');
+    emitter.emit('error', e);
     return callback(e);
   }
 };


### PR DESCRIPTION
As per issue #329 a race condition can occur that will emit events before the callback has had a chance to listen to them. We were able to replicate this about 60% of the time, causing timeout issues internally when in fact while looking at the trace logs, the search results returned.

Easiest to replicate with single result searches.

With these changes, we 100% verified that we no longer are missing events and it works as intended.

Thanks to @javefang for the fix!