### PR TITLE
prevent bind exceptions from crashing Node.js

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -317,6 +317,10 @@ function Client(options) {
 
   this.log = options.log.child({clazz: 'Client'}, true);
 
+  this.on('error', function(err) {
+    self.cb(err);
+  });
+
   this.timeout = parseInt((options.timeout || 0), 10);
   this.connectTimeout = parseInt((options.connectTimeout || 0), 10);
   this.idleTimeout = parseInt((options.idleTimeout || 0), 10);
@@ -362,6 +366,17 @@ function Client(options) {
 util.inherits(Client, EventEmitter);
 module.exports = Client;
 
+/**
+ * Default handler for error callbacks when
+ * one isn't set in the instance
+ */
+Client.prototype.cb = function(err, ret) {
+  if (err) {
+    console.error('Caught exception:', err);
+  } else {
+    console.log('Unhandled output:', ret);
+  }
+};
 
 /**
  * Sends an abandon request to the LDAP server.
@@ -480,6 +495,12 @@ Client.prototype.bind = function bind(name,
     credentials: credentials || '',
     controls: controls
   });
+
+  var self = this;
+  this.cb = function(err, ret) {
+    delete self.cb;
+    callback(err, ret);
+  };
 
   return this._send(req, [errors.LDAP_SUCCESS], null, callback, _bypass);
 };


### PR DESCRIPTION
This prevents node crashes from Client.bind() and etc.
We set a callback handler in the instance during bind()
and send errors to it.

Fixes https://github.com/mcavage/node-ldapjs/issues/356