### PR TITLE
Fix bitwise error when using Extensible Filter

### DIFF
--- a/lib/filters/ext_filter.js
+++ b/lib/filters/ext_filter.js
@@ -39,7 +39,7 @@ ExtensibleFilter.prototype.parse = function (ber) {
       this.value = ber.readString(tag);
       break;
     case 0x84:
-      this.dnAttributes = ber.readBoolean(tag);
+      this.dnAttributes = (ber.readString(tag) | 0) !== 0;
       break;
     default:
       throw new Error('Invalid ext_match filter type: 0x' + tag.toString(16));


### PR DESCRIPTION
This change is fixing an error that occurs when the extensible filter tries to retrieve the value for dnAttributes. 

This is reproducible when issuing a search with this filter:

```
const extFilter = new ldapjs.ExtensibleFilter({
                attribute: "userAccountControl",
                matchType: "userAccountControl",
                rule: "1.2.840.113556.1.4.803",
                value: "2",
                dnAttributes: true
});

ldapClient.search("<base dn>", { filter: extFilter }, (err, res) => { ... });
```
This will result in the error `Expected 0x1: got 0x84`

This should fix #430 and #439 