### PR TITLE
Remove dtrace-provider from optionalDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ client on your system:
 
     npm install ldapjs
 
+DTrace support is included in ldapjs. To enable it, `npm install dtrace-provider`
+
 ## License
 
 MIT.

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "vasync": "^1.6.4",
     "verror": "^1.8.1"
   },
-  "optionalDependencies": {
-    "dtrace-provider": "~0.8"
-  },
   "devDependencies": {
     "node-uuid": "^1.4.7",
     "faucet": "0.0.1",


### PR DESCRIPTION
See #399 and #286 for discussion.

It's pretty clear that dtrace dependency is causing too many problems for its own good. Searching for `dtrace` issues on this repository brings up plenty of issues.