### PR TITLE
basic SASL DIGEST-MD5 support

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -34,6 +34,7 @@ var DeleteRequest = messages.DeleteRequest;
 var ExtendedRequest = messages.ExtendedRequest;
 var ModifyRequest = messages.ModifyRequest;
 var ModifyDNRequest = messages.ModifyDNRequest;
+var SaslDigestMd5BindRequest = messages.SaslDigestMd5BindRequest;
 var SearchRequest = messages.SearchRequest;
 var UnbindRequest = messages.UnbindRequest;
 var UnbindResponse = messages.UnbindResponse;
@@ -448,6 +449,35 @@ Client.prototype.add = function add(name, entry, controls, callback) {
   return this._send(req, [errors.LDAP_SUCCESS], null, callback);
 };
 
+
+/**
+ * Performs first step for SASL DIGEST-MD5 auth
+ *
+ * @param {Function} callback of the form f(err, res).
+ * @throws {TypeError} on invalid input.
+ */
+Client.prototype.bind_sasl_digest_md5_step1 = function sasl_digest_md5_step1(callback, _bypass) {
+  assert.func(callback, 'callback')
+  const req = new SaslDigestMd5BindRequest({})
+  return this._send(req, [errors.LDAP_SASL_BIND_IN_PROGRESS], null, callback, _bypass)
+}
+
+/**
+ * Performs second step for SASL DIGEST-MD5 auth
+ *
+ * @param {String} challengeResponse SASL challenge response
+ * @param {Function} callback of the form f(err, res).
+ * @throws {TypeError} on invalid input.
+ */
+Client.prototype.bind_sasl_digest_md5_step2 = function sasl_digest_md5_step2(challengeResponse, callback, _bypass) {
+  assert.string(challengeResponse, 'challengeResponse')
+  assert.func(callback, 'callback')
+
+  const req = new SaslDigestMd5BindRequest({
+    challengeResponse: challengeResponse
+  })
+  return this._send(req, [errors.LDAP_SUCCESS], null, callback, _bypass)
+}
 
 /**
  * Performs a simple authentication against the server.

--- a/lib/messages/bind_response.js
+++ b/lib/messages/bind_response.js
@@ -18,6 +18,21 @@ function BindResponse(options) {
 }
 util.inherits(BindResponse, LDAPResult);
 
+BindResponse.prototype._parse = function(ber) {
+  assert.ok(ber)
+
+  if (!LDAPResult.prototype._parse.call(this, ber)) {
+    return false
+  }
+  const saslCredentials = ber.readString(135)
+  if (saslCredentials) {
+    this.saslCredentials = saslCredentials
+  }
+
+  return true
+}
+
+
 
 ///--- Exports
 

--- a/lib/messages/index.js
+++ b/lib/messages/index.js
@@ -20,6 +20,7 @@ var ModifyRequest = require('./modify_request');
 var ModifyResponse = require('./modify_response');
 var ModifyDNRequest = require('./moddn_request');
 var ModifyDNResponse = require('./moddn_response');
+var SaslDigestMd5BindRequest = require('./sasl_digest_md5_bind_request');
 var SearchRequest = require('./search_request');
 var SearchEntry = require('./search_entry');
 var SearchReference = require('./search_reference');
@@ -52,6 +53,7 @@ module.exports = {
   ModifyResponse: ModifyResponse,
   ModifyDNRequest: ModifyDNRequest,
   ModifyDNResponse: ModifyDNResponse,
+  SaslDigestMd5BindRequest: SaslDigestMd5BindRequest,
   SearchRequest: SearchRequest,
   SearchEntry: SearchEntry,
   SearchReference: SearchReference,

--- a/lib/messages/sasl_digest_md5_bind_request.js
+++ b/lib/messages/sasl_digest_md5_bind_request.js
@@ -1,0 +1,112 @@
+// Copyright 2011 Mark Cavage, Inc.  All rights reserved.
+
+var assert = require('assert-plus');
+var util = require('util');
+
+var asn1 = require('asn1');
+
+var LDAPMessage = require('./message');
+var Protocol = require('../protocol');
+
+///--- Globals
+
+var Ber = asn1.Ber;
+
+///--- API
+
+function BindRequest(options) {
+  options = options || {}
+  assert.object(options)
+
+  options.protocolOp = Protocol.LDAP_REQ_BIND
+  LDAPMessage.call(this, options)
+
+  this.version = 0x03
+  this.name = options.name || ''
+  this.challengeResponse = options.challengeResponse || ''
+}
+
+util.inherits(BindRequest, LDAPMessage)
+
+Object.defineProperties(BindRequest.prototype, {
+  type: {
+    get: function getType() { return 'SaslDigestMd5BindRequest' },
+    configurable: false,
+  },
+  _dn: {
+    get: function getDN() { return this.name },
+    configurable: false,
+  },
+})
+
+BindRequest.prototype._parse = function(ber) {
+  assert.ok(ber)
+
+  this.version = ber.readInt()
+  this.name = ber.readString()
+
+  const t = ber.peek()
+  // is this method used by server? - no idea what to do here
+
+  if (t !== Ber.Context) {
+    throw new Error('authentication 0x' + t.toString(16) + ' not supported')
+  }
+
+  return true
+}
+
+BindRequest.prototype._toBer = function(ber) {
+  assert.ok(ber)
+
+  ber.writeInt(this.version)
+  ber.writeString((this.name || '').toString())
+  ber.startSequence(0xa3)
+  ber.writeString('DIGEST-MD5')
+  if (this.challengeResponse) {
+    ber.writeString(this.challengeResponse)
+  }
+  ber.endSequence()
+  return ber
+}
+
+BindRequest.prototype._json = function(j) {
+  assert.ok(j)
+
+  j.version = this.version
+  j.name = this.name
+  j.challengeResponse = this.challengeResponse
+
+  return j
+}
+
+// very basic example how to generate SASL DIGEST-MD5 challenge response
+// you'll probably have to play with your particular LDAP server installation
+// this example worked to MS LDAP server (or AD)
+// example SASL challenge from this server:
+//    qop="auth,auth-int,auth-conf",cipher="3des,rc4",algorithm=md5-sess,nonce="SOMENONCE",charset=utf-8,realm="REALM"
+// cipher is ingored
+BindRequest.prototype.generate_response = function generate_response(input) {
+  // enforce  qop=auth
+  const qop = 'auth'
+  // any random string
+  const cnonce = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10)
+
+  // host - address of your LDAP server (not sure if it works with plain IP addresses)
+  // nonce - SASL nonce from step1
+  // realm - you can hardcode it of parse from step1
+  const { host, nonce, realm, username, password } = input
+  const uri = `ldap/${host}`
+  const secret = crypto.createHash('md5').update(username + ':' + realm + ':' + password).digest()
+  const ha1 = crypto.createHash('md5').update(secret).update(':' + nonce + ':' + cnonce).digest('hex')
+  const ha2 = crypto.createHash('md5').update('AUTHENTICATE:' + uri).digest('hex')
+  const nc = '00000001'
+  const digest = crypto.createHash('md5').update(ha1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + ha2).digest('hex')
+  const res = `username="${username}",realm="${realm}",nonce="${nonce}",cnonce="${cnonce}",nc=${nc},qop=${qop},digest-uri="${uri}",response=${digest},charset=utf-8`
+  return res
+}
+
+
+
+///--- Exports
+
+module.exports = BindRequest;


### PR DESCRIPTION
added very basic support for SASL DIGEST-MD5 bind
basically, bind flow should be smth like

1) run bind_sasl_digest_md5_step1()
2) parse SASL challenge from step1 (at least nonce is needed)
3) generate SASL challenge_response (there is an example in lib/messages/sasl_digest_md5_bind_request.js )
4) run bind_sasl_digest_md5_step1(challenge_response)