### PR TITLE
Remove assertion that change is Change

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -610,8 +610,7 @@ Client.prototype.exop = function exop(name, value, controls, callback) {
  */
 Client.prototype.modify = function modify(name, change, controls, callback) {
   assert.ok(name !== undefined, 'name');
-  assert.object(change, 'change');
-
+  
   var changes = [];
 
   function changeFromObject(change) {


### PR DESCRIPTION
Removed assertion that change is a change object to allow array to be passed.

Array is dealt with in later code where each item in the array is checked to be a change object.

Fixes issue #514 