### PR TITLE
RFC3062 server compatibility

### DIFF
--- a/lib/messages/ext_request.js
+++ b/lib/messages/ext_request.js
@@ -44,13 +44,17 @@ Object.defineProperties(ExtendedRequest.prototype, {
     configurable: false
   },
   value: {
-    get: function getValue() { return this.requestValue; },
+    get: function getValue() { return Buffer.isBuffer(this.requestValue) ? this.requestValue.toString('utf8') : this.requestValue; },
     set: function setValue(val) {
       if (!(Buffer.isBuffer(val) || typeof (val) === 'string'))
         throw new TypeError('value must be a buffer or a string');
 
       this.requestValue = val;
     },
+    configurable: false
+  },
+  valueBuffer: {
+    get: function getValue() { return Buffer.isBuffer(this.requestValue) ? this.requestValue : Buffer.alloc(0); }, //if value is a string, it cannot be reconstructed
     configurable: false
   }
 });
@@ -60,11 +64,7 @@ ExtendedRequest.prototype._parse = function (ber) {
 
   this.requestName = ber.readString(0x80);
   if (ber.peek() === 0x81)
-    try {
-      this.requestValue = ber.readString(0x81);
-    } catch (e) {
-      this.requestValue = ber.readBuffer(0x81);
-    }
+      this.requestValue = ber.readString(0x81, true);
 
   return true;
 };


### PR DESCRIPTION
Some extended messages, use `requestValue` not as a string, but for example a sequence.
This change makes it possible to retrieve the `requestValue` also as a buffer: `ExtendedRequest.valueBuffer`.

There is one minor change, `ExtendedRequest.value` now always returns a `string`.