### PR TITLE
Update ldap filter

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -171,9 +171,21 @@ function cloneFilter(input) {
   }
 }
 
+function escapedToHex(str) {
+  return str.replace(/\\([0-9a-f][^0-9a-f]|[0-9a-f]$|[^0-9a-f]|$)/gi, (match, p1) => {
+    if (!p1) {
+      return '\\5c';
+    }
+
+    const hexCode = p1.charCodeAt(0).toString(16);
+    const rest = p1.substring(1);
+    return `\\${hexCode}${rest}`;
+  });
+}
 
 function parseString(str) {
-  var generic = parents.parse(str);
+  const hexStr = escapedToHex(str);
+  const generic = parents.parse(hexStr);
   // The filter object(s) return from ldap-filter.parse lack the toBer/parse
   // decoration that native ldapjs filter possess.  cloneFilter adds that back.
   return cloneFilter(generic);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "asn1": "0.2.3",
     "assert-plus": "^1.0.0",
     "backoff": "^2.5.0",
-    "ldap-filter": "^0.2.2",
+    "ldap-filter": "^0.3.3",
     "dashdash": "^1.14.0",
     "once": "^1.4.0",
     "vasync": "^1.6.4",


### PR DESCRIPTION
- Update ldap-filter
- Convert escaped characters to Ascii hex code

ldap-filter v0.3.0 has a few [breaking changes](https://github.com/pfmooney/node-ldap-filter/blob/master/CHANGES.md#030).

Some of the tests are breaking because they don't allow special characters in an attribute name.