### PR TITLE
Fixing issue #434 (can delete attributes)

### DIFF
--- a/lib/change.js
+++ b/lib/change.js
@@ -82,7 +82,7 @@ Object.defineProperties(Change.prototype, {
         val[k].forEach(function (v) {
           _attr.addValue(v.toString());
         });
-      } else {
+      } else if (val[k] !== undefined && val[k] !== null) {
         _attr.addValue(val[k].toString());
       }
       this._modification = _attr;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -506,6 +506,22 @@ test('modify change plain object success', function (t) {
 });
 
 
+// https://github.com/ldapjs/node-ldapjs/pull/435
+test('can delete attributes', function (t) {
+  try {
+    var change = new Change({
+      type: 'Delete',
+      modification: { cn: null }
+    });
+    t.ok(true);
+    t.end();
+  } catch (err) {
+    t.ifError(err);
+    t.end();
+  }
+});
+
+
 test('modify array success', function (t) {
   var changes = [
     new Change({


### PR DESCRIPTION
Now the change/modification value can be set to `undefined` or `null`, in order to indicate a non multi-valued attribute. As result `changes[0]._modification._vals` in `return this._send(req, [errors.LDAP_SUCCESS], null, callback)` (see [client.js#672][1]) is an empty array. The request is accepted by the LDAP-server (OpenLDAP) and the attribute is deleted.

To execute this operation use the following template (replace *attributeName* by the real name):

    let change = { operation : 'delete', modification: { attributeName : undefined }};
    client.modify(dn, change, (err, res) => { ... });


[1]: https://github.com/mcavage/node-ldapjs/blob/master/lib/client/client.js#L672