### PR TITLE
add a callback optionnal parameter for server.close method

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -732,8 +732,8 @@ Server.prototype.listenFD = function (fd) {
   this.port = fd;
   return this.server.listenFD(fd);
 };
-Server.prototype.close = function () {
-  return this.server.close();
+Server.prototype.close = function (callback) {
+  return this.server.close(callback);
 };
 Server.prototype.address = function () {
   return this.server.address();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -310,4 +310,32 @@ test('non-strict routing', function (t) {
       });
     });
   });
+
+  test('close accept a callback', function (t) {
+    server = ldap.createServer();
+    // callback is called when the server is closed
+    server.close(function(err){
+      t.end();
+    });
+  });
+
+  test('close without error calls callback', function (t) {
+    server = ldap.createServer();
+    // when the server is closed without error, the callback parameter is undefined
+    server.listen(389,'127.0.0.1',function(err){
+      server.close(function(err){
+        t.error(err);
+        t.end();
+      });
+    });
+  });
+
+  test('close passes error to callback', function (t) {
+    server = ldap.createServer();
+    // when the server is closed with an error, the error is the first parameter of the callback
+    server.close(function(err){
+      t.ok(err);
+      t.end();
+    });
+  });
 });


### PR DESCRIPTION
net and tls server.close method accept an optional callback parameter.
ldapjs server.close method delegates to net or tls server.close method and accept now an optional callback parameter...

closes #438