### PR TITLE
Fix escapedToHex

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -165,14 +165,13 @@ function cloneFilter (input) {
 }
 
 function escapedToHex (str) {
-  return str.replace(/\\([0-9a-f][^0-9a-f]|[0-9a-f]$|[^0-9a-f]|$)/gi, function (match, p1) {
+  return str.replace(/\\([0-9a-f](?![0-9a-f])|[^0-9a-f]|$)/gi, function (match, p1) {
     if (!p1) {
       return '\\5c'
     }
 
     const hexCode = p1.charCodeAt(0).toString(16)
-    const rest = p1.substring(1)
-    return '\\' + hexCode + rest
+    return '\\' + hexCode
   })
 }
 

--- a/test/filters/parse.test.js
+++ b/test/filters/parse.test.js
@@ -27,12 +27,12 @@ test('GH-50 = in filter', function (t) {
 })
 
 test('convert to hex code', function (t) {
-  const str = 'foo=bar\\(abcd\\e\\fg\\h\\69\\'
+  const str = 'foo=bar\\(abcd\\e\\fg\\h\\69\\a'
   const f = parse(str)
   t.ok(f)
   t.equal(f.attribute, 'foo')
-  t.equal(f.value, 'bar(abcdefghi\\')
-  t.equal(f.toString(), '(foo=bar\\28abcdefghi\\5c)')
+  t.equal(f.value, 'bar(abcdefghia')
+  t.equal(f.toString(), '(foo=bar\\28abcdefghia)')
   t.end()
 })
 
@@ -58,6 +58,16 @@ test(') in filter', function (t) {
 
 test('\\ in filter', function (t) {
   const str = '(foo=bar\\\\)'
+  const f = parse(str)
+  t.ok(f)
+  t.equal(f.attribute, 'foo')
+  t.equal(f.value, 'bar\\')
+  t.equal(f.toString(), '(foo=bar\\5c)')
+  t.end()
+})
+
+test('not escaped \\ at end of filter', function (t) {
+  const str = 'foo=bar\\'
   const f = parse(str)
   t.ok(f)
   t.equal(f.attribute, 'foo')

--- a/test/filters/parse.test.js
+++ b/test/filters/parse.test.js
@@ -26,6 +26,16 @@ test('GH-50 = in filter', function (t) {
   t.end()
 })
 
+test('convert to hex code', function (t) {
+  const str = 'foo=bar\\(abcd\\e\\fg\\h\\69\\'
+  const f = parse(str)
+  t.ok(f)
+  t.equal(f.attribute, 'foo')
+  t.equal(f.value, 'bar(abcdefghi\\')
+  t.equal(f.toString(), '(foo=bar\\28abcdefghi\\5c)')
+  t.end()
+})
+
 test('( in filter', function (t) {
   const str = '(foo=bar\\()'
   const f = parse(str)


### PR DESCRIPTION
fixes [escapedToHex](https://github.com/ldapjs/node-ldapjs/blob/a113953e0d91211eb945d2a3952c84b7af6de41c/lib/filters/index.js#L167) when two escaped characters are next to each other

```js
escapedToHex("\\(\\)")
// before fix: "\\28\\)"
//  after fix: "\\28\\29"
```