### PR TITLE
Handle connection refused and connection timeouts gracefully

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -120,8 +120,8 @@ function Client (options) {
 
   this.log = options.log.child({ clazz: 'Client' }, true)
 
-  this.on('error', function(err) {
-    self.cb(err);
+  this.on('error', function (err) {
+    self.cb(err)
   })
 
   this.timeout = parseInt((options.timeout || 0), 10)
@@ -176,7 +176,7 @@ module.exports = Client
  * Default handler for error callbacks when
  * one isn't set in the instance
  */
-Client.prototype.cb = function(err, ret) {
+Client.prototype.cb = function (err, ret) {
   if (err) {
     this.log.error('Caught exception:', err)
   } else {
@@ -299,7 +299,7 @@ Client.prototype.bind = function bind (name,
   })
 
   var self = this
-  this.cb = function(err, ret) {
+  this.cb = function (err, ret) {
     delete self.cb
     callback(err, ret)
   }

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -282,13 +282,13 @@ Client.prototype.bind = function bind (name,
     controls: controls
   })
 
-  // While we are binding to the server, register the callback as error handler
+  // Connection errors will be reported to the bind callback too (useful when the LDAP server is not available)
   var self = this
   function callbackWrapper (err, ret) {
-    self.removeListener('error', callbackWrapper)
+    self.removeListener('connectError', callbackWrapper)
     callback(err, ret)
   }
-  this.addListener('error', callbackWrapper)
+  this.addListener('connectError', callbackWrapper)
 
   return this._send(req, [errors.LDAP_SUCCESS], null, callbackWrapper, _bypass)
 }

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -120,6 +120,10 @@ function Client (options) {
 
   this.log = options.log.child({ clazz: 'Client' }, true)
 
+  this.on('error', function(err) {
+    self.cb(err);
+  })
+
   this.timeout = parseInt((options.timeout || 0), 10)
   this.connectTimeout = parseInt((options.connectTimeout || 0), 10)
   this.idleTimeout = parseInt((options.idleTimeout || 0), 10)
@@ -167,6 +171,18 @@ function Client (options) {
 }
 util.inherits(Client, EventEmitter)
 module.exports = Client
+
+/**
+ * Default handler for error callbacks when
+ * one isn't set in the instance
+ */
+Client.prototype.cb = function(err, ret) {
+  if (err) {
+    console.error('Caught exception:', err)
+  } else {
+    console.log('Unhandled output:', ret)
+  }
+}
 
 /**
  * Sends an abandon request to the LDAP server.
@@ -281,6 +297,12 @@ Client.prototype.bind = function bind (name,
     credentials: credentials || '',
     controls: controls
   })
+
+  var self = this
+  this.cb = function(err, ret) {
+    delete self.cb
+    callback(err, ret)
+  }
 
   return this._send(req, [errors.LDAP_SUCCESS], null, callback, _bypass)
 }

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -120,10 +120,6 @@ function Client (options) {
 
   this.log = options.log.child({ clazz: 'Client' }, true)
 
-  this.on('error', function (err) {
-    self.cb(err)
-  })
-
   this.timeout = parseInt((options.timeout || 0), 10)
   this.connectTimeout = parseInt((options.connectTimeout || 0), 10)
   this.idleTimeout = parseInt((options.idleTimeout || 0), 10)
@@ -171,18 +167,6 @@ function Client (options) {
 }
 util.inherits(Client, EventEmitter)
 module.exports = Client
-
-/**
- * Default handler for error callbacks when
- * one isn't set in the instance
- */
-Client.prototype.cb = function (err, ret) {
-  if (err) {
-    this.log.error('Caught exception:', err)
-  } else {
-    this.log.info('Unhandled output:', ret)
-  }
-}
 
 /**
  * Sends an abandon request to the LDAP server.
@@ -298,13 +282,15 @@ Client.prototype.bind = function bind (name,
     controls: controls
   })
 
+  // While we are binding to the server, register the callback as error handler
   var self = this
-  this.cb = function (err, ret) {
-    delete self.cb
+  function callbackWrapper (err, ret) {
+    self.removeListener('error', callbackWrapper)
     callback(err, ret)
   }
+  this.addListener('error', callbackWrapper)
 
-  return this._send(req, [errors.LDAP_SUCCESS], null, callback, _bypass)
+  return this._send(req, [errors.LDAP_SUCCESS], null, callbackWrapper, _bypass)
 }
 
 /**

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1013,6 +1013,8 @@ Client.prototype.connect = function connect () {
     // Communicate the last-encountered error
     if (err instanceof ConnectionError) {
       self.emit('connectTimeout', err)
+    } else if (err.code === 'ECONNREFUSED') {
+      self.emit('connectRefused', err)
     } else {
       self.emit('error', err)
     }

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -178,9 +178,9 @@ module.exports = Client
  */
 Client.prototype.cb = function(err, ret) {
   if (err) {
-    console.error('Caught exception:', err)
+    this.log.error('Caught exception:', err)
   } else {
-    console.log('Unhandled output:', ret)
+    this.log.info('Unhandled output:', ret)
   }
 }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1463,3 +1463,17 @@ tap.test('resultError handling', function (t) {
     t.fail('should not get error')
   }
 })
+
+tap.test('connection refused', function (t) {
+  const client = ldap.createClient({
+    url: 'ldap://0.0.0.0'
+  })
+
+  client.bind('cn=root', 'secret', function (err, res) {
+    t.true(err)
+    t.type(err, Error)
+    t.equals(err.code, 'ECONNREFUSED')
+    t.false(res)
+    t.end()
+  })
+})

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1477,3 +1477,28 @@ tap.test('connection refused', function (t) {
     t.end()
   })
 })
+
+tap.test('connection timeout', function (t) {
+  const client = ldap.createClient({
+    url: 'ldap://example.org',
+    connectTimeout: 1,
+    timeout: 1
+  })
+
+  var done = false
+
+  setTimeout(function () {
+    if (!done) {
+      throw new Error('LDAPJS waited for the server for too long')
+    }
+  }, 2000)
+
+  client.bind('cn=root', 'secret', function (err, res) {
+    t.true(err)
+    t.type(err, Error)
+    t.equals(err.message, 'connection timeout')
+    done = true
+    t.false(res)
+    t.end()
+  })
+})


### PR DESCRIPTION
This pull request rebases the work from https://github.com/ldapjs/node-ldapjs/pull/433 to the next branch. It also adds tests to the two cases concerned by the PR:
- connection refused (LDAP server not started)
- connection timeout (firewall problem)

I took this as a opportunity to dive deeper into the code to understand what was actually causing the error to be thrown, I hope the code is a little cleaner than a blind handling of all errors (which caused other tests to fail). The issue was a poor handling of connection errors in the bind method. Since it's the first async method, it is the one that should report connection issues to the server, which it did not. Another issue was the handling of connection refused errors that caused a general error in ldapjs. Sending the exception to the bind callback avoids crashing the whole node process.