### PR TITLE
Handle expired TLS certificate errors in client

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1014,6 +1014,8 @@ Client.prototype.connect = function connect () {
       self.emit('connectTimeout', err)
     } else if (err.code === 'ECONNREFUSED') {
       self.emit('connectRefused', err)
+    } else if (err.code === 'CERT_HAS_EXPIRED' || err.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+      self.emit('connectError', err)
     } else {
       self.emit('error', err)
     }


### PR DESCRIPTION
This PR contains the fix suggested by @tfrancois in #589. I am willing to add some tests as well, but I would need some guidance about how to set up such a test.