### PR TITLE
Remove spaces from DNs in SearchRequest

### DIFF
--- a/lib/messages/search_request.js
+++ b/lib/messages/search_request.js
@@ -105,7 +105,13 @@ SearchRequest.prototype._parse = function (ber) {
 SearchRequest.prototype._toBer = function (ber) {
   assert.ok(ber)
 
-  ber.writeString(this.baseObject.toString())
+  // Format only with commas, since that is what RFC 4514 mandates.
+  // There's a gotcha here: even though it's called baseObject,
+  //  it can be a string or a DN object.
+  var formattedDN = dn.DN.isDN(this.baseObject)
+    ? this.baseObject.format({ skipSpace: true })
+    : this.baseObject.toString()
+  ber.writeString(formattedDN)
   ber.writeEnumeration(this._scope)
   ber.writeEnumeration(this.derefAliases)
   ber.writeInt(this.sizeLimit)

--- a/test/messages/search_request.test.js
+++ b/test/messages/search_request.test.js
@@ -78,7 +78,8 @@ test('toBer', function (t) {
   t.equal(ber.readSequence(), 0x30)
   t.equal(ber.readInt(), 123)
   t.equal(ber.readSequence(), 0x63)
-  t.equal(ber.readString(), 'cn=foo, o=test')
+  // Make sure we've removed spaces from between RDNs:
+  t.equal(ber.readString(), 'cn=foo,o=test')
   t.equal(ber.readEnumeration(), 1)
   t.equal(ber.readEnumeration(), 2)
   t.equal(ber.readInt(), 10)


### PR DESCRIPTION
This change fixes how DNs are serialized into BER for SearchRequest messages.
It drops spaces around commas, since it breaks some LDAP servers that expect
the DN to be separated by comma only as per RFC 4514. The old format of
spaced separators from LDAPv2 is thus no longer used.

For #611