### PR TITLE
Use a random TCP port for testing timeouts/rejects

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "verror": "^1.8.1"
   },
   "devDependencies": {
+    "get-port": "^5.1.1",
     "husky": "^3.0.4",
     "snazzy": "^8.0.0",
     "standard": "^14.0.2",


### PR DESCRIPTION
This fixes a test failure when the host has something listening
on the LDAP TCP port. Previously, the test cases would assume
that the port was free and they would not connect.

For #612