### PR TITLE
Replace instanceof check with duck-typing in Filter#toBer mixin

### DIFF
--- a/lib/filters/filter.js
+++ b/lib/filters/filter.js
@@ -2,13 +2,9 @@
 
 // var assert = require('assert')
 
-var asn1 = require('asn1')
-
 var Protocol = require('../protocol')
 
 /// --- Globals
-
-var BerWriter = asn1.BerWriter
 
 var TYPES = {
   and: Protocol.FILTER_AND,
@@ -40,7 +36,7 @@ function isFilter (filter) {
 
 function mixin (target) {
   target.prototype.toBer = function toBer (ber) {
-    if (!ber || !(ber instanceof BerWriter)) { throw new TypeError('ber (BerWriter) required') }
+    if (!ber) { throw new TypeError('ber (BerWriter) required') }
 
     ber.startSequence(TYPES[this.type])
     ber = this._toBer(ber)

--- a/lib/filters/filter.js
+++ b/lib/filters/filter.js
@@ -45,7 +45,7 @@ function isBerWriter (ber) {
 
 function mixin (target) {
   target.prototype.toBer = function toBer (ber) {
-    if (!isBerWriter(ber)) { throw new TypeError('ber (BerWriter) required') }
+    if (isBerWriter(ber) === false) { throw new TypeError('ber (BerWriter) required') }
 
     ber.startSequence(TYPES[this.type])
     ber = this._toBer(ber)

--- a/lib/filters/filter.js
+++ b/lib/filters/filter.js
@@ -35,7 +35,8 @@ function isFilter (filter) {
 }
 
 function isBerWriter (ber) {
-  return (
+  return Boolean(
+    ber &&
     typeof (ber) === 'object' &&
     typeof (ber.startSequence) === 'function' &&
     typeof (ber.endSequence) === 'function'
@@ -44,7 +45,7 @@ function isBerWriter (ber) {
 
 function mixin (target) {
   target.prototype.toBer = function toBer (ber) {
-    if (!ber || !isBerWriter(ber)) { throw new TypeError('ber (BerWriter) required') }
+    if (!isBerWriter(ber)) { throw new TypeError('ber (BerWriter) required') }
 
     ber.startSequence(TYPES[this.type])
     ber = this._toBer(ber)

--- a/lib/filters/filter.js
+++ b/lib/filters/filter.js
@@ -34,9 +34,17 @@ function isFilter (filter) {
   return false
 }
 
+function isBerWriter (ber) {
+  return (
+    typeof (ber) === 'object' &&
+    typeof (ber.startSequence) === 'function' &&
+    typeof (ber.endSequence) === 'function'
+  )
+}
+
 function mixin (target) {
   target.prototype.toBer = function toBer (ber) {
-    if (!ber) { throw new TypeError('ber (BerWriter) required') }
+    if (!ber || !isBerWriter(ber)) { throw new TypeError('ber (BerWriter) required') }
 
     ber.startSequence(TYPES[this.type])
     ber = this._toBer(ber)


### PR DESCRIPTION
This fixes #629 where, if this package was used in 2 instances (e.g. depended upon by 2 different packages) where one passes a Client object to the other, they would not recognize each other's `BerWriter` instances and throw an error on `.search()` with filters.