### PR TITLE
Remove spaces in searchResEntry objectName

### DIFF
--- a/lib/messages/search_entry.js
+++ b/lib/messages/search_entry.js
@@ -171,7 +171,8 @@ SearchEntry.prototype._parse = function (ber) {
 SearchEntry.prototype._toBer = function (ber) {
   assert.ok(ber)
 
-  ber.writeString(this.objectName.toString())
+  var formattedObjectName = this.objectName.format({ skipSpace: true })
+  ber.writeString(formattedObjectName)
   ber.startSequence()
   this.attributes.forEach(function (a) {
     // This may or may not be an attribute

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -682,7 +682,7 @@ tap.test('search basic', function (t) {
     res.on('searchEntry', function (entry) {
       t.ok(entry)
       t.ok(entry instanceof ldap.SearchEntry)
-      t.equal(entry.dn.toString(), 'cn=test, ' + SUFFIX)
+      t.equal(entry.dn.toString(), 'cn=test,' + SUFFIX)
       t.ok(entry.attributes)
       t.ok(entry.attributes.length)
       t.equal(entry.attributes[0].type, 'cn')
@@ -1118,7 +1118,7 @@ tap.test('GH-21 binary attributes', function (t) {
     res.on('searchEntry', function (entry) {
       t.ok(entry)
       t.ok(entry instanceof ldap.SearchEntry)
-      t.equal(entry.dn.toString(), 'cn=bin, ' + SUFFIX)
+      t.equal(entry.dn.toString(), 'cn=bin,' + SUFFIX)
       t.ok(entry.attributes)
       t.ok(entry.attributes.length)
       t.equal(entry.attributes[0].type, 'foo;binary')
@@ -1159,7 +1159,7 @@ tap.test('GH-23 case insensitive attribute filtering', function (t) {
     res.on('searchEntry', function (entry) {
       t.ok(entry)
       t.ok(entry instanceof ldap.SearchEntry)
-      t.equal(entry.dn.toString(), 'cn=test, ' + SUFFIX)
+      t.equal(entry.dn.toString(), 'cn=test,' + SUFFIX)
       t.ok(entry.attributes)
       t.ok(entry.attributes.length)
       t.equal(entry.attributes[0].type, 'cn')
@@ -1191,7 +1191,7 @@ tap.test('GH-24 attribute selection of *', function (t) {
     res.on('searchEntry', function (entry) {
       t.ok(entry)
       t.ok(entry instanceof ldap.SearchEntry)
-      t.equal(entry.dn.toString(), 'cn=test, ' + SUFFIX)
+      t.equal(entry.dn.toString(), 'cn=test,' + SUFFIX)
       t.ok(entry.attributes)
       t.ok(entry.attributes.length)
       t.equal(entry.attributes[0].type, 'cn')

--- a/test/messages/search_entry.test.js
+++ b/test/messages/search_entry.test.js
@@ -74,7 +74,7 @@ test('toBer', function (t) {
   t.equal(ber.readSequence(), 0x30)
   t.equal(ber.readInt(), 123)
   t.equal(ber.readSequence(), 0x64)
-  t.equal(ber.readString(), 'cn=foo, o=test')
+  t.equal(ber.readString(), 'cn=foo,o=test')
   t.ok(ber.readSequence())
 
   t.ok(ber.readSequence())

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -107,8 +107,8 @@ tap.test('route order', function (t) {
   const server = ldap.createServer()
   const sock = t.context.sock
   const dnShort = SUFFIX
-  const dnMed = 'dc=sub, ' + SUFFIX
-  const dnLong = 'dc=long, dc=sub, ' + SUFFIX
+  const dnMed = 'dc=sub,' + SUFFIX
+  const dnLong = 'dc=long,dc=sub,' + SUFFIX
 
   // Mount routes out of order
   server.search(dnMed, generateHandler(dnMed))


### PR DESCRIPTION
This PR addresses issue #645

This change fixes how DNs are serialised into BER for searchResEntry messages, and is related to the following other issues and PRs (#611, #613).

The change is required as it breaks clients that are expecting the reply to be comma separated only and not comma space `, `
