### PR TITLE
Remove lowercase conversion on searchResEntry objectName

### DIFF
--- a/lib/dn.js
+++ b/lib/dn.js
@@ -46,14 +46,13 @@ RDN.prototype.set = function rdnSet (name, value, opts) {
   assert.string(value, 'value (string) required')
 
   var self = this
-  var lname = name.toLowerCase()
-  this.attrs[lname] = {
+  this.attrs[name] = {
     value: value,
     name: name
   }
   if (opts && typeof (opts) === 'object') {
     Object.keys(opts).forEach(function (k) {
-      if (k !== 'value') { self.attrs[lname][k] = opts[k] }
+      if (k !== 'value') { self.attrs[name][k] = opts[k] }
     })
   }
 }


### PR DESCRIPTION
This PR addresses issue #645

This change fixes how DNs are formatted for searchResEntry messages.

Existing behavior forces the object class in the response to be in lower case regardless of how it is stored in the server.

eg. data in the database that is stored like the following:
```
camelCase=camelCase,cn=foo,o=test
```
This will be returned to the requester in the following format:
```
camelcase=camelCase,cn=foo,o=test
```

The new behavior once this PR is merged will allow for the server to send the response in the same format that the data is stored in the database.

eg.
```
camelCase=camelCase,cn=foo,o=test
```