### PR TITLE
made controls parameter optional in client starttls

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -670,7 +670,7 @@ Client.prototype.starttls = function starttls (options,
   _bypass) {
   assert.optionalObject(options)
   options = options || {}
-  
+
   if (typeof (controls) === 'function') {
     callback = controls
     controls = []

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -670,6 +670,15 @@ Client.prototype.starttls = function starttls (options,
   _bypass) {
   assert.optionalObject(options)
   options = options || {}
+  
+  if (typeof (controls) === 'function') {
+    callback = controls
+    controls = []
+  } else {
+    controls = validateControls(controls)
+  }
+  assert.func(callback, 'callback')
+
   callback = once(callback)
   var self = this
 


### PR DESCRIPTION
Regarding #326 

Warning: I was unable to properly test this code and confirm it works.  I did not actually get TLS to work.  I suspect I messed up the certificates somehow.  

I only think this code works is because the error messages are different.  
Before changes, there was an Object.key assert error - which happens when there are missing arguments (controls).  
After changes, there is a "unsupported extended operation" error - which points to TLS certificates not being properly setup (but omitting controls is fine). 
