### PR TITLE
[Docs] Improved documentation

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -131,7 +131,7 @@ Example:
     });
 
 # del
-`del(dn, controls, callbak)`
+`del(dn, controls, callback)`
 
 
 Deletes an entry from the LDAP server.


### PR DESCRIPTION
Fix spelling error on `docs/client.md`

The #del <whatever> previously has an argument `callbak`.
I believe it was a typo and have corrected that to `callback`.