### PR TITLE
Remove use of logging methods in conditional tests

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -716,12 +716,12 @@ Client.prototype.starttls = function starttls (options,
          */
         secure.removeAllListeners('error')
         secure.on('data', function onData (data) {
-          if (self.log.trace()) { self.log.trace('data event: %s', util.inspect(data)) }
+          self.log.trace('data event: %s', util.inspect(data))
 
           self._tracker.parser.write(data)
         })
         secure.on('error', function (err) {
-          if (self.log.trace()) { self.log.trace({ err: err }, 'error event: %s', new Error().stack) }
+          self.log.trace({ err: err }, 'error event: %s', new Error().stack)
 
           self.emit('error', err)
           sock.destroy()
@@ -866,7 +866,7 @@ Client.prototype.connect = function connect () {
     }
 
     socket.on('data', function onData (data) {
-      if (log.trace) { log.trace('data event: %s', util.inspect(data)) }
+      log.trace('data event: %s', util.inspect(data))
 
       tracker.parser.write(data)
     })
@@ -955,19 +955,19 @@ Client.prototype.connect = function connect () {
     ((socket.socket) ? socket.socket : socket).once('close',
       self._onClose.bind(self))
     socket.on('end', function onEnd () {
-      if (log.trace()) { log.trace('end event') }
+      log.trace('end event')
 
       self.emit('end')
       socket.end()
     })
     socket.on('error', function onSocketError (err) {
-      if (log.trace()) { log.trace({ err: err }, 'error event: %s', new Error().stack) }
+      log.trace({ err: err }, 'error event: %s', new Error().stack)
 
       self.emit('error', err)
       socket.destroy()
     })
     socket.on('timeout', function onTimeout () {
-      if (log.trace()) { log.trace('timeout event') }
+      log.trace('timeout event')
 
       self.emit('socketTimeout')
       socket.end()
@@ -1069,7 +1069,7 @@ Client.prototype._onClose = function _onClose (closeError) {
 
   ((socket.socket) ? socket.socket : socket).removeAllListeners('close')
 
-  if (this.log.trace()) { this.log.trace('close event had_err=%s', closeError ? 'yes' : 'no') }
+  this.log.trace('close event had_err=%s', closeError ? 'yes' : 'no')
 
   this.emit('close', closeError)
   // On close we have to walk the outstanding messages and go invoke their
@@ -1198,7 +1198,7 @@ Client.prototype._sendSocket = function _sendSocket (message,
   function messageCallback (msg) {
     if (timer) { clearTimeout(timer) }
 
-    if (log.trace()) { log.trace({ msg: msg ? msg.json : null }, 'response received') }
+    log.trace({ msg: msg ? msg.json : null }, 'response received')
 
     if (expect === 'abandon') { return sendResult('end', null) }
 
@@ -1266,7 +1266,7 @@ Client.prototype._sendSocket = function _sendSocket (message,
     timer = setTimeout(onRequestTimeout, self.timeout)
   }
 
-  if (log.trace()) { log.trace('sending request %j', message.json) }
+  log.trace('sending request %j', message.json)
 
   try {
     return conn.write(message.toBer(), writeCallback)

--- a/lib/messages/message.js
+++ b/lib/messages/message.js
@@ -65,7 +65,7 @@ LDAPMessage.prototype.toString = function () {
 LDAPMessage.prototype.parse = function (ber) {
   assert.ok(ber)
 
-  if (this.log.trace()) { this.log.trace('parse: data=%s', util.inspect(ber.buffer)) }
+  this.log.trace('parse: data=%s', util.inspect(ber.buffer))
 
   // Delegate off to the specific type to parse
   this._parse(ber, ber.length)
@@ -80,7 +80,7 @@ LDAPMessage.prototype.parse = function (ber) {
     }
   }
 
-  if (this.log.trace()) { this.log.trace('Parsing done: %j', this.json) }
+  this.log.trace('Parsing done: %j', this.json)
   return true
 }
 

--- a/lib/messages/result.js
+++ b/lib/messages/result.js
@@ -47,7 +47,7 @@ LDAPResult.prototype.end = function (status) {
   if (typeof (status) === 'number') { this.status = status }
 
   const ber = this.toBer()
-  if (this.log.debug()) { this.log.debug('%s: sending:  %j', this.connection.ldap.id, this.json) }
+  this.log.debug('%s: sending:  %j', this.connection.ldap.id, this.json)
 
   try {
     const self = this

--- a/lib/messages/search_response.js
+++ b/lib/messages/search_response.js
@@ -76,7 +76,7 @@ SearchResponse.prototype.send = function (entry, nofiltering) {
   }
 
   try {
-    if (this.log.debug) { this.log.debug('%s: sending:  %j', this.connection.ldap.id, entry.json) }
+    this.log.debug('%s: sending:  %j', this.connection.ldap.id, entry.json)
 
     this.connection.write(entry.toBer())
     this.sentEntries++

--- a/lib/server.js
+++ b/lib/server.js
@@ -329,7 +329,7 @@ function Server (options) {
       req.logId = c.ldap.id + '::' + req.messageID
       req.startTime = new Date().getTime()
 
-      if (log.debug()) { log.debug('%s: message received: req=%j', c.ldap.id, req.json) }
+      log.debug('%s: message received: req=%j', c.ldap.id, req.json)
 
       const res = getResponse(req)
       if (!res) {
@@ -429,7 +429,7 @@ function Server (options) {
     })
 
     c.on('data', function (data) {
-      if (log.trace()) { log.trace('data on %s: %s', c.ldap.id, util.inspect(data)) }
+      log.trace('data on %s: %s', c.ldap.id, util.inspect(data))
 
       c.parser.write(data)
     })


### PR DESCRIPTION
To address issue #676 .

Use of log methods (e.g. `log.trace()`) in conditional tests prior to actually logging messages yields undesirable behavior when using Pino as an alternative to Bunyan (and potentially other Bunyan-like packages).

1. Pino methods have void return values and always fail the conditional test
2. Pino method calls with no parameters still produce a logging event with several default values but no message field

Additionally, the default behavior for Bunyan and similar loggers is to filter events based on instance config options. The conditionals are not necessary.