### PR TITLE
Fix crash in res.send()

### DIFF
--- a/lib/messages/search_response.js
+++ b/lib/messages/search_response.js
@@ -42,7 +42,7 @@ SearchResponse.prototype.send = function (entry, nofiltering) {
   const self = this
 
   const savedAttrs = {}
-  const save = null
+  let save = null
   if (entry instanceof SearchEntry || entry instanceof SearchReference) {
     if (!entry.messageID) { entry.messageID = this.messageID }
     if (entry.messageID !== this.messageID) { throw new Error('SearchEntry messageID mismatch') }
@@ -66,7 +66,7 @@ SearchResponse.prototype.send = function (entry, nofiltering) {
       }
     })
 
-    const save = entry
+    save = entry
     entry = new SearchEntry({
       objectName: typeof (save.dn) === 'string' ? parseDN(save.dn) : save.dn,
       messageID: self.messageID,


### PR DESCRIPTION
In commit c6fa25985b078ce0ba27da50d1d8676d3e18fe30, "var" usage
was replaced with const. The code previously worked because "var"
has function scoping unlike const which has block scoping.

TypeError: Cannot read property 'attributes' of null