### PR TITLE
Emit error event if other error events are not listened to

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -20,6 +20,10 @@ The code to create a new client looks like:
       url: ['ldap://127.0.0.1:1389', 'ldap://127.0.0.2:1389']
     });
 
+    client.on('error', (err) => {
+      // handle connection error
+    })
+
 You can use `ldap://` or `ldaps://`; the latter would connect over SSL (note
 that this will not use the LDAP TLS extended operation, but literally an SSL
 connection to port 636, as in LDAP v2). The full set of options to create a
@@ -70,6 +74,25 @@ more sophisticated control, you can provide an Object with the properties
 `failAfter` (default: `Infinity`).
 After the reconnect you maybe need to [bind](#bind) again.
 
+## Client events
+
+The client is an `EventEmitter` and can emit the following events:
+
+|Event          |Description                                               |
+|---------------|----------------------------------------------------------|
+|error          |General error                                             |
+|connectRefused |Server refused connection. Most likely bad authentication |
+|connectTimeout |Server timeout                                            |
+|connectError   |Socket connection error                                   |
+|setupError     |Setup error after successful connection                   |
+|socketTimeout  |Socket timeout                                            |
+|resultError    |Search result error                                       |
+|timeout        |Search result timeout                                     |
+|destroy        |After client is disconnected                              |
+|end            |Socket end event                                          |
+|close          |Socket closed                                             |
+|connect        |Client connected                                          |
+|idle           |Idle timeout reached                                      |
 
 ## Common patterns
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1029,9 +1029,9 @@ Client.prototype.connect = function connect () {
     self.log.debug('failed to connect after %d attempts', failAfter)
     // Communicate the last-encountered error
     if (err instanceof ConnectionError) {
-      self.emit('connectTimeout', err)
+      self.emitError('connectTimeout', err)
     } else if (err.code === 'ECONNREFUSED') {
-      self.emit('connectRefused', err)
+      self.emitError('connectRefused', err)
     } else {
       self.emit('error', err)
     }
@@ -1276,4 +1276,16 @@ Client.prototype._sendSocket = function _sendSocket (message,
     log.trace({ err: e }, 'Error writing message to socket')
     return callback(e)
   }
+}
+
+Client.prototype.emitError = function emitError (event, err) {
+  if (event !== 'error' && err && this.listenerCount(event) === 0) {
+    if (typeof err === 'string') {
+      err = event + ': ' + err
+    } else if (err.message) {
+      err.message = event + ': ' + err.message
+    }
+    this.emit('error', err)
+  }
+  this.emit(event, err)
 }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -32,6 +32,9 @@ Object.defineProperties(LDAPError.prototype, {
     get: function getMessage () {
       return this.lde_message || this.name
     },
+    set: function setMessage (message) {
+      this.lde_message = message
+    },
     configurable: false
   },
   dn: {


### PR DESCRIPTION
Emit error event if other error events are not listened to.

Currently if someone wants to catch client errors they have to subscribe to multiple error events

```js
client.on("error", (err) => {
  assert.ifError(err);
});
client.on("setupError", (err) => {
  assert.ifError(err);
});
client.on("connectError", (err) => {
  assert.ifError(err);
});
client.on("connectTimeout", (err) => {
  assert.ifError(err);
});
client.on("connectRefused", (err) => {
  assert.ifError(err);
});
```

This PR will allow them to just subscribe to the `error` event to catch all of them but still allow them to subscribe to more if they want to.

### TODO:

- [ ] Add Tests