### PR TITLE
object to Attribute conversion on client should not call .toString()

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -236,10 +236,10 @@ Client.prototype.add = function add (name, entry, controls, callback) {
       const attr = new Attribute({ type: k })
       if (Array.isArray(save[k])) {
         save[k].forEach(function (v) {
-          attr.addValue(v.toString())
+          attr.addValue(v)
         })
       } else {
-        attr.addValue(save[k].toString())
+        attr.addValue(save[k])
       }
       entry.push(attr)
     })


### PR DESCRIPTION
**Bug:**
- When trying to add a binary element, such as `jpegPhoto` of type `Buffer`, the client's add method will serialize it when converting a user object to an array of attributes, which works fine for most cases, but not for binary data on Buffers.

The following pseudo-code results in an invalid image on an LDAP server
```
client.add(dn, {jpegPhoto: (buffer)});
```

Adding as an attribute works as expected:
```
const attr = new Attribute({type: 'jpegPhoto'});
attr.addValue(buffer);

client.add(dn, [attr]);
```
