### PR TITLE
Add missing error emit.

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1274,6 +1274,7 @@ Client.prototype._sendSocket = function _sendSocket (message,
     if (timer) { clearTimeout(timer) }
 
     log.trace({ err: e }, 'Error writing message to socket')
+    self.emit('error', e)
     return callback(e)
   }
 }


### PR DESCRIPTION
This is a small one. The exception is never emitted as an error, so is only seen when traceing. Stumbled over it while debugging something else. 

Signed-off-by: Philippe Seewer <philippe.seewer@bfh.ch>