### PR TITLE
SearchPager: Implement queueing events until a listener appears

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -630,9 +630,9 @@ Client.prototype.search = function search (base,
       callback: callback,
       controls: controls,
       pageSize: size,
-      pagePause: pageOpts.pagePause
+      pagePause: pageOpts.pagePause,
+      sendRequest: sendRequest
     })
-    pager.on('search', sendRequest)
     pager.begin()
   } else {
     sendRequest(controls, new CorkedEmitter(), callback)

--- a/lib/client/search_pager.js
+++ b/lib/client/search_pager.js
@@ -10,6 +10,8 @@ const assert = require('assert-plus')
 // var Protocol = require('../protocol')
 const PagedControl = require('../controls/paged_results_control.js')
 
+const CorkedEmitter = require('../corked_emitter.js')
+
 /// --- API
 
 /**
@@ -29,19 +31,20 @@ const PagedControl = require('../controls/paged_results_control.js')
  *                will be emitted (and 'end' will not be).  By listening to
  *                'pageError', a successful search that lacks paging will be
  *                able to emit 'end'.
- * 3. search    - Emitted as an internal event to trigger another client search.
  */
 function SearchPager (opts) {
   assert.object(opts)
   assert.func(opts.callback)
   assert.number(opts.pageSize)
+  assert.func(opts.sendRequest)
 
-  EventEmitter.call(this, {})
+  CorkedEmitter.call(this, {})
 
   this.callback = opts.callback
   this.controls = opts.controls
   this.pageSize = opts.pageSize
   this.pagePause = opts.pagePause
+  this.sendRequest = opts.sendRequest
 
   this.controls.forEach(function (control) {
     if (control.type === PagedControl.OID) {
@@ -60,7 +63,7 @@ function SearchPager (opts) {
   emitter.on('error', this._onError.bind(this))
   this.childEmitter = emitter
 }
-util.inherits(SearchPager, EventEmitter)
+util.inherits(SearchPager, CorkedEmitter)
 module.exports = SearchPager
 
 /**
@@ -143,8 +146,7 @@ SearchPager.prototype._nextPage = function _nextPage (cookie) {
     }
   }))
 
-  this.emit('search', controls, this.childEmitter,
-    this._sendCallback.bind(this))
+  this.sendRequest(controls, this.childEmitter, this._sendCallback.bind(this))
 }
 
 /**

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -900,16 +900,14 @@ tap.test('search paged', { timeout: 10000 }, function (t) {
   })
 
   tap.test('paged - search with delayed event listener binding', function (t) {
-    t.context.client.search('cn=paged', { filter: '(objectclass=*)', paged : true }, function (err, res) {
+    t.context.client.search('cn=paged', { filter: '(objectclass=*)', paged: true }, function (err, res) {
       t.error(err)
       setTimeout(() => {
-	let gotEntry = 0
-	console.log('registering searchEntry');
-	
+        let gotEntry = 0
         res.on('searchEntry', function () {
           gotEntry++
         })
-	res.on('error', function (err) {
+        res.on('error', function (err) {
           t.fail(err)
         })
         res.on('end', function () {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -899,6 +899,27 @@ tap.test('search paged', { timeout: 10000 }, function (t) {
     })
   })
 
+  tap.test('paged - search with delayed event listener binding', function (t) {
+    t.context.client.search('cn=paged', { filter: '(objectclass=*)', paged : true }, function (err, res) {
+      t.error(err)
+      setTimeout(() => {
+	let gotEntry = 0
+	console.log('registering searchEntry');
+	
+        res.on('searchEntry', function () {
+          gotEntry++
+        })
+	res.on('error', function (err) {
+          t.fail(err)
+        })
+        res.on('end', function () {
+          t.equal(gotEntry, 1000)
+          t.end()
+        })
+      }, 100)
+    })
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
This fixes the same problems for paged searches as does
https://github.com/ldapjs/node-ldapjs/pull/610 for unpaged searches.

By passing an EventEmitter via callback there exist cases when events
are emitted before listeners are registered, resulting in missed
events.

The Change turns SearchPager into a CorkedEmitter which is already
used as a solution for non paged searches. Doing so requires the
internal 'search' event to be dropped.

This change adapts a test case originally by László Szűcs (@ifroz).

Signed-off-by: Philippe Seewer <philippe.seewer@bfh.ch>