### PR TITLE
connection router to accomodate multithreading

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -550,3 +550,76 @@ To test out this example, try:
 $ ldapsearch -H ldap://localhost:389 -x -D cn=demo,dc=example,dc=com \
   -w demo -b "dc=example,dc=com" objectclass=*
 ```
+
+# Multi-threaded Server
+
+This example demonstrates multi-threading via the `cluster` module utilizing a `net` server for initial socket receipt.  An alternate example demonstrating use of the `connectionRouter` `serverOptions` hook is available in the `examples` directory.
+
+```
+const cluster = require('cluster');
+const ldap = require('ldapjs');
+const net = require('net');
+const os = require('os');
+
+const threads = [];
+threads.getNext = function () {
+    return (Math.floor(Math.random() * this.length));
+};
+
+const serverOptions = {
+    port: 1389
+};
+
+if (cluster.isMaster) {
+    const server = net.createServer(serverOptions, (socket) => {
+        socket.pause();
+        console.log('ldapjs client requesting connection');
+        let routeTo = threads.getNext();
+        threads[routeTo].send({ type: 'connection' }, socket);
+    });
+
+    for (let i = 0; i < os.cpus().length; i++) {
+        let thread = cluster.fork({
+            'id': i
+        });
+        thread.id = i;
+        thread.on('message', function (msg) {
+
+        });
+        threads.push(thread);
+    }
+
+    server.listen(serverOptions.port, function () {
+        console.log('ldapjs listening at ldap://127.0.0.1:' + serverOptions.port);
+    });
+} else {
+    const server = ldap.createServer(serverOptions);
+
+    let threadId = process.env.id;
+
+    process.on('message', (msg, socket) => {
+        switch (msg.type) {
+            case 'connection':
+                server.newConnection(socket);
+                socket.resume();
+                console.log('ldapjs client connection accepted on ' + threadId.toString());
+        }
+    });
+
+    server.search('dc=example', function (req, res, next) {
+        console.log('ldapjs search initiated on ' + threadId.toString());
+        var obj = {
+            dn: req.dn.toString(),
+            attributes: {
+                objectclass: ['organization', 'top'],
+                o: 'example'
+            }
+        };
+
+        if (req.filter.matches(obj.attributes))
+            res.send(obj);
+
+        res.end();
+    });
+}
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -555,7 +555,7 @@ $ ldapsearch -H ldap://localhost:389 -x -D cn=demo,dc=example,dc=com \
 
 This example demonstrates multi-threading via the `cluster` module utilizing a `net` server for initial socket receipt.  An alternate example demonstrating use of the `connectionRouter` `serverOptions` hook is available in the `examples` directory.
 
-```
+```js
 const cluster = require('cluster');
 const ldap = require('ldapjs');
 const net = require('net');

--- a/examples/cluster-threading-net-server.js
+++ b/examples/cluster-threading-net-server.js
@@ -1,0 +1,66 @@
+const cluster = require('cluster');
+const ldap = require('ldapjs');
+const net = require('net');
+const os = require('os');
+
+const threads = [];
+threads.getNext = function () {
+    return (Math.floor(Math.random() * this.length));
+};
+
+const serverOptions = {
+    port: 1389
+};
+
+if (cluster.isMaster) {
+    const server = net.createServer(serverOptions, (socket) => {
+        socket.pause();
+        console.log('ldapjs client requesting connection');
+        let routeTo = threads.getNext();
+        threads[routeTo].send({ type: 'connection' }, socket);
+    });
+
+    for (let i = 0; i < os.cpus().length; i++) {
+        let thread = cluster.fork({
+            'id': i
+        });
+        thread.id = i;
+        thread.on('message', function (msg) {
+
+        });
+        threads.push(thread);
+    }
+
+    server.listen(serverOptions.port, function () {
+        console.log('ldapjs listening at ldap://127.0.0.1:' + serverOptions.port);
+    });
+} else {
+    const server = ldap.createServer(serverOptions);
+
+    let threadId = process.env.id;
+
+    process.on('message', (msg, socket) => {
+        switch (msg.type) {
+            case 'connection':
+                server.newConnection(socket);
+                socket.resume();
+                console.log('ldapjs client connection accepted on ' + threadId.toString());
+        }
+    });
+
+    server.search('dc=example', function (req, res, next) {
+        console.log('ldapjs search initiated on ' + threadId.toString());
+        var obj = {
+            dn: req.dn.toString(),
+            attributes: {
+                objectclass: ['organization', 'top'],
+                o: 'example'
+            }
+        };
+
+        if (req.filter.matches(obj.attributes))
+            res.send(obj);
+
+        res.end();
+    });
+}

--- a/examples/cluster-threading-net-server.js
+++ b/examples/cluster-threading-net-server.js
@@ -1,66 +1,65 @@
-const cluster = require('cluster');
-const ldap = require('ldapjs');
-const net = require('net');
-const os = require('os');
+const cluster = require('cluster')
+const ldap = require('ldapjs')
+const net = require('net')
+const os = require('os')
 
-const threads = [];
+const threads = []
 threads.getNext = function () {
-    return (Math.floor(Math.random() * this.length));
-};
+  return (Math.floor(Math.random() * this.length))
+}
 
 const serverOptions = {
-    port: 1389
-};
+  port: 1389
+}
 
 if (cluster.isMaster) {
-    const server = net.createServer(serverOptions, (socket) => {
-        socket.pause();
-        console.log('ldapjs client requesting connection');
-        let routeTo = threads.getNext();
-        threads[routeTo].send({ type: 'connection' }, socket);
-    });
+  const server = net.createServer(serverOptions, (socket) => {
+    socket.pause()
+    console.log('ldapjs client requesting connection')
+    const routeTo = threads.getNext()
+    threads[routeTo].send({ type: 'connection' }, socket)
+  })
 
-    for (let i = 0; i < os.cpus().length; i++) {
-        let thread = cluster.fork({
-            'id': i
-        });
-        thread.id = i;
-        thread.on('message', function (msg) {
+  for (let i = 0; i < os.cpus().length; i++) {
+    const thread = cluster.fork({
+      id: i
+    })
+    thread.id = i
+    thread.on('message', function () {
 
-        });
-        threads.push(thread);
+    })
+    threads.push(thread)
+  }
+
+  server.listen(serverOptions.port, function () {
+    console.log('ldapjs listening at ldap://127.0.0.1:' + serverOptions.port)
+  })
+} else {
+  const server = ldap.createServer(serverOptions)
+
+  const threadId = process.env.id
+
+  process.on('message', (msg, socket) => {
+    switch (msg.type) {
+      case 'connection':
+        server.newConnection(socket)
+        socket.resume()
+        console.log('ldapjs client connection accepted on ' + threadId.toString())
+    }
+  })
+
+  server.search('dc=example', function (req, res) {
+    console.log('ldapjs search initiated on ' + threadId.toString())
+    const obj = {
+      dn: req.dn.toString(),
+      attributes: {
+        objectclass: ['organization', 'top'],
+        o: 'example'
+      }
     }
 
-    server.listen(serverOptions.port, function () {
-        console.log('ldapjs listening at ldap://127.0.0.1:' + serverOptions.port);
-    });
-} else {
-    const server = ldap.createServer(serverOptions);
+    if (req.filter.matches(obj.attributes)) { res.send(obj) }
 
-    let threadId = process.env.id;
-
-    process.on('message', (msg, socket) => {
-        switch (msg.type) {
-            case 'connection':
-                server.newConnection(socket);
-                socket.resume();
-                console.log('ldapjs client connection accepted on ' + threadId.toString());
-        }
-    });
-
-    server.search('dc=example', function (req, res, next) {
-        console.log('ldapjs search initiated on ' + threadId.toString());
-        var obj = {
-            dn: req.dn.toString(),
-            attributes: {
-                objectclass: ['organization', 'top'],
-                o: 'example'
-            }
-        };
-
-        if (req.filter.matches(obj.attributes))
-            res.send(obj);
-
-        res.end();
-    });
+    res.end()
+  })
 }

--- a/examples/cluster-threading.js
+++ b/examples/cluster-threading.js
@@ -1,66 +1,65 @@
-const cluster = require('cluster');
-const ldap = require('ldapjs');
-const os = require('os');
+const cluster = require('cluster')
+const ldap = require('ldapjs')
+const os = require('os')
 
-const threads = [];
+const threads = []
 threads.getNext = function () {
-    return (Math.floor(Math.random() * this.length));
-};
+  return (Math.floor(Math.random() * this.length))
+}
 
 const serverOptions = {
-    connectionRouter: (socket) => {
-        socket.pause();
-        console.log('ldapjs client requesting connection');
-        let routeTo = threads.getNext();
-        threads[routeTo].send({ type: 'connection' }, socket);
-    }
-};
+  connectionRouter: (socket) => {
+    socket.pause()
+    console.log('ldapjs client requesting connection')
+    const routeTo = threads.getNext()
+    threads[routeTo].send({ type: 'connection' }, socket)
+  }
+}
 
-const server = ldap.createServer(serverOptions);
+const server = ldap.createServer(serverOptions)
 
 if (cluster.isMaster) {
-    for (let i = 0; i < os.cpus().length; i++) {
-        let thread = cluster.fork({
-            'id': i
-        });
-        thread.id = i;
-        thread.on('message', function (msg) {
+  for (let i = 0; i < os.cpus().length; i++) {
+    const thread = cluster.fork({
+      id: i
+    })
+    thread.id = i
+    thread.on('message', function () {
 
-        });
-        threads.push(thread);
+    })
+    threads.push(thread)
+  }
+
+  server.listen(1389, function () {
+    console.log('ldapjs listening at ' + server.url)
+  })
+} else {
+  const threadId = process.env.id
+  serverOptions.connectionRouter = () => {
+    console.log('should not be hit')
+  }
+
+  process.on('message', (msg, socket) => {
+    switch (msg.type) {
+      case 'connection':
+        server.newConnection(socket)
+        socket.resume()
+        console.log('ldapjs client connection accepted on ' + threadId.toString())
+    }
+  })
+
+  server.search('dc=example', function (req, res) {
+    console.log('ldapjs search initiated on ' + threadId.toString())
+    const obj = {
+      dn: req.dn.toString(),
+      attributes: {
+        objectclass: ['organization', 'top'],
+        o: 'example'
+      }
     }
 
-    server.listen(1389, function () {
-        console.log('ldapjs listening at ' + server.url);
-    });
-} else {
-    let threadId = process.env.id;
-    serverOptions.connectionRouter = (connection) => {
-        console.log('should not be hit');
-    };
+    if (req.filter.matches(obj.attributes)) { res.send(obj) }
 
-    process.on('message', (msg, socket) => {
-        switch (msg.type) {
-            case 'connection':
-                server.newConnection(socket);
-                socket.resume();
-                console.log('ldapjs client connection accepted on ' + threadId.toString());
-        }
-    });
-
-    server.search('dc=example', function (req, res, next) {
-        console.log('ldapjs search initiated on ' + threadId.toString());
-        var obj = {
-            dn: req.dn.toString(),
-            attributes: {
-                objectclass: ['organization', 'top'],
-                o: 'example'
-            }
-        };
-
-        if (req.filter.matches(obj.attributes))
-            res.send(obj);
-
-        res.end();
-    });
+    res.end()
+  })
 }

--- a/examples/cluster-threading.js
+++ b/examples/cluster-threading.js
@@ -1,0 +1,66 @@
+const cluster = require('cluster');
+const ldap = require('ldapjs');
+const os = require('os');
+
+const threads = [];
+threads.getNext = function () {
+    return (Math.floor(Math.random() * this.length));
+};
+
+const serverOptions = {
+    connectionRouter: (socket) => {
+        socket.pause();
+        console.log('ldapjs client requesting connection');
+        let routeTo = threads.getNext();
+        threads[routeTo].send({ type: 'connection' }, socket);
+    }
+};
+
+const server = ldap.createServer(serverOptions);
+
+if (cluster.isMaster) {
+    for (let i = 0; i < os.cpus().length; i++) {
+        let thread = cluster.fork({
+            'id': i
+        });
+        thread.id = i;
+        thread.on('message', function (msg) {
+
+        });
+        threads.push(thread);
+    }
+
+    server.listen(1389, function () {
+        console.log('ldapjs listening at ' + server.url);
+    });
+} else {
+    let threadId = process.env.id;
+    serverOptions.connectionRouter = (connection) => {
+        console.log('should not be hit');
+    };
+
+    process.on('message', (msg, socket) => {
+        switch (msg.type) {
+            case 'connection':
+                server.newConnection(socket);
+                socket.resume();
+                console.log('ldapjs client connection accepted on ' + threadId.toString());
+        }
+    });
+
+    server.search('dc=example', function (req, res, next) {
+        console.log('ldapjs search initiated on ' + threadId.toString());
+        var obj = {
+            dn: req.dn.toString(),
+            attributes: {
+                objectclass: ['organization', 'top'],
+                o: 'example'
+            }
+        };
+
+        if (req.filter.matches(obj.attributes))
+            res.send(obj);
+
+        res.end();
+    });
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -314,6 +314,8 @@ function Server (options) {
   }
 
   self.newConnection = function (conn) {
+    // TODO: make `newConnection` available on the `Server` prototype
+    // https://github.com/ldapjs/node-ldapjs/pull/727/files#r636572294
     setupConnection(conn)
     log.trace('new connection from %s', conn.ldap.id)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -438,9 +438,9 @@ function Server (options) {
   this.routes = {}
   if ((options.cert || options.certificate) && options.key) {
     options.cert = options.cert || options.certificate
-    this.server = tls.createServer(options, options.connectionRouter ? options.connectionRouter : self.newConnection)
+    this.server = tls.createServer(options, self.newConnection)
   } else {
-    this.server = net.createServer(options.connectionRouter ? options.connectionRouter : self.newConnection)
+    this.server = net.createServer(self.newConnection)
   }
   this.server.log = options.log
   this.server.ldap = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -313,7 +313,7 @@ function Server (options) {
     return c
   }
 
-  function newConnection (conn) {
+  self.newConnection = function (conn) {
     setupConnection(conn)
     log.trace('new connection from %s', conn.ldap.id)
 
@@ -438,9 +438,9 @@ function Server (options) {
   this.routes = {}
   if ((options.cert || options.certificate) && options.key) {
     options.cert = options.cert || options.certificate
-    this.server = tls.createServer(options, newConnection)
+    this.server = tls.createServer(options, options.connectionRouter ? options.connectionRouter : self.newConnection)
   } else {
-    this.server = net.createServer(newConnection)
+    this.server = net.createServer(options.connectionRouter ? options.connectionRouter : self.newConnection)
   }
   this.server.log = options.log
   this.server.ldap = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -438,9 +438,9 @@ function Server (options) {
   this.routes = {}
   if ((options.cert || options.certificate) && options.key) {
     options.cert = options.cert || options.certificate
-    this.server = tls.createServer(options, self.newConnection)
+    this.server = tls.createServer(options, options.connectionRouter ? options.connectionRouter : self.newConnection)
   } else {
-    this.server = net.createServer(self.newConnection)
+    this.server = net.createServer(options.connectionRouter ? options.connectionRouter : self.newConnection)
   }
   this.server.log = options.log
   this.server.ldap = {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const net = require('net')
 const tap = require('tap')
 const vasync = require('vasync')
 const { getSock } = require('./utils')

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -334,7 +334,7 @@ tap.test('close passes error to callback', function (t) {
 })
 
 tap.test('multithreading support via external server', function (t) {
-  let serverOptions = { }
+  const serverOptions = { }
   const server = ldap.createServer(serverOptions)
   const fauxServer = net.createServer(serverOptions, (connection) => {
     server.newConnection(connection)
@@ -358,7 +358,7 @@ tap.test('multithreading support via external server', function (t) {
 })
 
 tap.test('multithreading support via hook', function (t) {
-  let serverOptions = {
+  const serverOptions = {
     connectionRouter: (connection) => {
       server.newConnection(connection)
     }


### PR DESCRIPTION
connection router hook added to accommodate multithreaded servers

e.g. passing `options.connectionRouter(connection)` will allow for:

    function connectionRouter(connection) {
        sendToThread(findRoute(connection), connection);
    }
    
    function sendToThread(threadId, connection) {
        ...wrap in packet for IPC and send to thread...
    }
    
    function threadMessage(message) {
        notListeningServerOnChildThread.newConnection(message.connection);
    }

in order to preserve extant functionality while adding multi-threading support.