### PR TITLE
Update url.js

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -10,7 +10,11 @@ module.exports = {
   parse: function (urlStr, parseDN) {
     let parsedURL
     try {
-      parsedURL = new url.URL(urlStr)
+      if(url.URL){
+        parsedURL = new url.URL(urlStr)
+      }else {
+        parsedURL = new URL(urlStr)
+      }
     } catch (error) {
       throw new TypeError(urlStr + ' is an invalid LDAP url (scope)')
     }


### PR DESCRIPTION
to fix "url.URL is not a constructor" in new nodejs api