### PR TITLE
fix: client.add not adding buffers properly

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -238,6 +238,8 @@ Client.prototype.add = function add (name, entry, controls, callback) {
         save[k].forEach(function (v) {
           attr.addValue(v.toString())
         })
+      } else if (Buffer.isBuffer(save[k])) {
+        attr.addValue(save[k]);
       } else {
         attr.addValue(save[k].toString())
       }

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -239,7 +239,7 @@ Client.prototype.add = function add (name, entry, controls, callback) {
           attr.addValue(v.toString())
         })
       } else if (Buffer.isBuffer(save[k])) {
-        attr.addValue(save[k]);
+        attr.addValue(save[k])
       } else {
         attr.addValue(save[k].toString())
       }


### PR DESCRIPTION
Fixed while getting AD thumbnailPhoto to work.

To repro, add a thumbnailPhoto to AD.

Note: I don't believe I ever reported this problem, but I've been using the fix for a long time.