### PR TITLE
Allow "socket" option to pass for example a SOCKS5 proxy client socket

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -166,7 +166,7 @@ function Client (options) {
 
   this._socket = null
   this.connected = false
-  this.connect()
+  this.connect(options.socket)
 }
 util.inherits(Client, EventEmitter)
 module.exports = Client
@@ -785,7 +785,7 @@ Client.prototype.destroy = function destroy (err) {
 /**
  * Initiate LDAP connection.
  */
-Client.prototype.connect = function connect () {
+Client.prototype.connect = function connect (__socket) {
   if (this.connecting || this.connected) {
     return
   }
@@ -833,7 +833,12 @@ Client.prototype.connect = function connect () {
       socket = tls.connect(port, host, self.tlsOptions)
       socket.once('secureConnect', onConnect)
     } else {
-      socket = net.connect(port, host)
+      if (__socket) {
+        socket = __socket;
+        setImmediate(() => { socket.emit('connect') }); // This is for the socket.once('connect', ...) below
+      } else {
+        socket = net.connect(port, host);
+      }
       socket.once('connect', onConnect)
     }
     socket.once('error', onResult)


### PR DESCRIPTION
Thank you very much for this excellent module.

Please consider my pull request: I would need this in order to be able to use ldapjs with an pre-existing SocksClient socket (that comes from 'socks') with 'ldap://' and STARTTLS.

('ldaps://' already works with a pre-existing socket which can be passed via 'tlsOptions'.)

You could mention the ability to use a proxy on the documentation website http://ldapjs.org/client.html . If need be, I can contribute my example code.

Best regards, Laszlo