### PR TITLE
force socket to be closed on destroy

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -776,9 +776,11 @@ Client.prototype.destroy = function destroy (err) {
   })
   if (this.connected) {
     this.unbind()
-  } else if (this._socket) {
+  }
+  if (this._socket) {
     this._socket.destroy()
   }
+
   this.emit('destroy', err)
 }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1747,3 +1747,24 @@ tap.only('emitError', function (t) {
 
   t.end()
 })
+
+tap.test('socket destroy', function (t) {
+  const clt = ldap.createClient({
+    socketPath: t.context.socketPath,
+    bindDN: BIND_DN,
+    bindCredentials: BIND_PW
+  })
+
+  clt.once('connect', function () {
+    t.ok(clt)
+    clt._socket.once('close', function () {
+      t.ok(!clt.connected)
+      t.end()
+    })
+    clt.destroy()
+  })
+
+  clt.once('destroy', function () {
+    t.ok(clt.destroyed)
+  })
+})


### PR DESCRIPTION
This will force destroy a socket after calling destroy. 
Fixing the file descriptor leak issue, see https://github.com/ldapjs/node-ldapjs/issues/605