### PR TITLE
Add Note on Client Error Handling to Documentation

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -63,6 +63,13 @@ Known compatible loggers are:
 + [Bunyan](https://www.npmjs.com/package/bunyan)
 + [Pino](https://www.npmjs.com/package/pino)
 
+
+### Note On Error Handling
+
+The client is an `EventEmitter`. If you don't register an error handler and
+e.g. a connection error occurs, Node.js will print a stack trace and exit the
+process ([reference](https://nodejs.org/api/events.html#error-events)).
+
 ## Connection management
 
 As LDAP is a stateful protocol (as opposed to HTTP), having connections torn


### PR DESCRIPTION
Some people (including myself) attempt to use the LDAP client without registering a handler to the _error_ event, since e.g. connection errors are supposed to be included in the callbacks of other methods. Since the client is an `EventEmitter` however the Node.js process will exit if the handler is missing.

This PR adds a note to the documentation to avoid confusion as suggested in #356 and #498.