### PR TITLE
Remove coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,13 +45,3 @@ jobs:
         run: npm install
       - name: Run Tests
         run: npm run test:ci
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,0 @@
-check-coverage: false
-
-files:
-  - 'test/**/*.test.js'

--- a/.taprc.yml
+++ b/.taprc.yml
@@ -1,0 +1,10 @@
+# These coverage percentages meet thresholds present in the code base
+# as of 2022-03-27. As the code gets broken out into maintainable modules,
+# these thresholds should increase until they are all at 100%.
+branches: 75
+functions: 80
+lines: 85
+statements: 85
+
+files:
+  - 'test/**/*.test.js'


### PR DESCRIPTION
This codebase is not well covered to begin with. Plus, we can simply fail from thresholds. Eventually, we should be able to use thresholds of 100% and tools like Coveralls would be completely pointless.