### PR TITLE
Replace node-filter (resolves #622)

### DIFF
--- a/lib/filters/and_filter.js
+++ b/lib/filters/and_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/approx_filter.js
+++ b/lib/filters/approx_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/equality_filter.js
+++ b/lib/filters/equality_filter.js
@@ -4,7 +4,7 @@ const assert = require('assert-plus')
 const util = require('util')
 
 const ASN1 = require('@ldapjs/asn1').Ber
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 
@@ -20,7 +20,7 @@ module.exports = EqualityFilter
 EqualityFilter.prototype.matches = function (target, strictAttrCase) {
   assert.object(target, 'target')
 
-  const tv = parents.getAttrValue(target, this.attribute, strictAttrCase)
+  const tv = parents.getAttrValue({ sourceObject: target, attributeName: this.attribute, strictCase: strictAttrCase })
   let value = this.value
 
   if (this.attribute.toLowerCase() === 'objectclass') {
@@ -29,13 +29,19 @@ EqualityFilter.prototype.matches = function (target, strictAttrCase) {
      * implementation behaves in this manner.
      */
     value = value.toLowerCase()
-    return parents.testValues(function (v) {
-      return value === v.toLowerCase()
-    }, tv)
+    return parents.testValues({
+      rule: function (v) {
+        return value === v.toLowerCase()
+      },
+      value: tv
+    })
   } else {
-    return parents.testValues(function (v) {
-      return value === v
-    }, tv)
+    return parents.testValues({
+      rule: function (v) {
+        return value === v
+      },
+      value: tv
+    })
   }
 }
 

--- a/lib/filters/ext_filter.js
+++ b/lib/filters/ext_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/ge_filter.js
+++ b/lib/filters/ge_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 
 const asn1 = require('@ldapjs/asn1')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Protocol = require('@ldapjs/protocol')
 

--- a/lib/filters/le_filter.js
+++ b/lib/filters/le_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/not_filter.js
+++ b/lib/filters/not_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/or_filter.js
+++ b/lib/filters/or_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/presence_filter.js
+++ b/lib/filters/presence_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/lib/filters/substr_filter.js
+++ b/lib/filters/substr_filter.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const util = require('util')
 
-const parents = require('ldap-filter')
+const parents = require('@ldapjs/filter')
 
 const Filter = require('./filter')
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "dependencies": {
     "@ldapjs/asn1": "^1.0.0",
     "@ldapjs/controls": "^1.0.0",
+    "@ldapjs/filter": "^1.0.0-rc.1",
     "@ldapjs/protocol": "^1.0.0",
     "abstract-logging": "^2.0.0",
     "assert-plus": "^1.0.0",
     "backoff": "^2.5.0",
-    "ldap-filter": "^0.3.3",
     "once": "^1.4.0",
     "vasync": "^2.2.0",
     "verror": "^1.8.1"


### PR DESCRIPTION
As titled. This will replace the `node-filter` package with the `@ldapjs/filter` package. I'm going to leave it as the `-rc.` release for this PR since it's merging into the `next` branch. I suspect I will end up doing a lot more work in `@ldapjs/filter` as I start working on `@ldapjs/messages`.