### PR TITLE
Document correct connection error in client documentation

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -22,7 +22,7 @@ const client = ldap.createClient({
   url: ['ldap://127.0.0.1:1389', 'ldap://127.0.0.2:1389']
 });
 
-client.on('error', (err) => {
+client.on('connectError', (err) => {
   // handle connection error
 })
 ```


### PR DESCRIPTION
When the connection fails, e.g. due to a faulty dns lookup, the `connectError` event is emitted, not `error`.
https://github.com/ldapjs/node-ldapjs/blob/master/lib/client/client.js#L806-L815

The documentation however says to listen on `error` to catch these events.
```js
client.on('error', (err) => {
  // handle connection error
})
```
Not sure if this is an error in documentation or the wrong event is used to emit an error. This PR just updates the documentation.

