### PR TITLE
Server learned to listens on any address (IPv4 or IPv6) when host is omitted

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -80,8 +80,11 @@ Example:
 `listen(port, [host], [callback])`
 
 Begin accepting connections on the specified port and host. If the host is
-omitted, the server will accept connections directed to any IPv4 address
-(INADDR\_ANY).
+omitted, the server will accept connections on the unspecified IPv6 address (::)
+when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
+
+In most operating systems, listening to the unspecified IPv6 address (::)
+may cause the net.Server to also listen on the unspecified IPv4 address (0.0.0.0).
 
 This function is asynchronous. The last parameter callback will be called when
 the server has been bound.

--- a/lib/server.js
+++ b/lib/server.js
@@ -682,7 +682,7 @@ Server.prototype.listen = function (port, host, callback) {
 
   if (typeof (host) === 'function') {
     callback = host
-    host = '0.0.0.0'
+    host = undefined
   }
   if (typeof (port) === 'string' && /^[0-9]+$/.test(port)) {
     // Disambiguate between string ports and file paths


### PR DESCRIPTION
Actually when using `listen` and host is omitted the server accepts connections directed to any IPv4 address but not to IPv6 addresses.

With this patch the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.

Note: In most operating systems, listening to the unspecified IPv6 address (::) may cause the server to also listen on the unspecified IPv4 address (0.0.0.0).

This pull request aligns ldapjs server behavior with that of Net.server.