### PR TITLE
transcontextual safe type checks

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,15 +47,15 @@ function mergeFunctionArgs (argv, start, end) {
   const handlers = []
 
   for (let i = start; i < end; i++) {
-    if (argv[i] instanceof Array) {
+    if (Array.isArray(argv[i])) {
       const arr = argv[i]
       for (let j = 0; j < arr.length; j++) {
-        if (!(arr[j] instanceof Function)) {
+        if ((typeof arr[j] !== 'function')) {
           throw new TypeError('Invalid argument type: ' + typeof (arr[j]))
         }
         handlers.push(arr[j])
       }
-    } else if (argv[i] instanceof Function) {
+    } else if (typeof argv[i] === 'function') {
       handlers.push(argv[i])
     } else {
       throw new TypeError('Invalid argument type: ' + typeof (argv[i]))

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,7 +50,7 @@ function mergeFunctionArgs (argv, start, end) {
     if (Array.isArray(argv[i])) {
       const arr = argv[i]
       for (let j = 0; j < arr.length; j++) {
-        if ((typeof arr[j] !== 'function')) {
+        if (typeof arr[j] !== 'function') {
           throw new TypeError('Invalid argument type: ' + typeof (arr[j]))
         }
         handlers.push(arr[j])


### PR DESCRIPTION
In case the supplied function goes into a different context (using vm.SourceTextModule for example) the "instanceof" checks fail.

typeof obj === 'function' and Array.isArray are true among contexts. 

BTW: as far I read isArray has explicitly been created for cross-realm situations.