### PR TITLE
Provide accessor for SearchEntry object

### DIFF
--- a/lib/messages/search_response.js
+++ b/lib/messages/search_response.js
@@ -74,7 +74,10 @@ SearchResponse.prototype.send = function (entry, nofiltering) {
     entry = new SearchEntry({
       objectName: typeof (save.dn) === 'string' ? parseDN(save.dn) : save.dn,
       messageId: self.messageId,
-      attributes: Attribute.fromObject(entry.attributes)
+      attributes: Attribute.fromObject(entry.attributes),
+      getAttribute: function(a) {
+        this.attributes.filter(f => f.type === a).map(m -> m.values).pop()
+      }
     })
   }
 
@@ -100,7 +103,8 @@ SearchResponse.prototype.createSearchEntry = function (object) {
   const entry = new SearchEntry({
     messageId: this.messageId,
     objectName: object.objectName || object.dn,
-    attributes: object.attributes ?? []
+    attributes: object.attributes ?? [],
+    getAttribute: object.getAttribute ?? function() { return null }
   })
   return entry
 }


### PR DESCRIPTION
Proposing this small change as a more intuitive way to get attribute values under v3.

Related to my question about, and the response to, issue #919. The code change borrows ideas from #841.
