### PR TITLE
server: prevent crash on blank DN bind

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -854,11 +854,11 @@ Server.prototype._getHandlerChain = function _getHandlerChain (req) {
   }
 
   // Otherwise, match via DN rules
-  assert.ok(req.dn)
   const keys = this._sortedRouteKeys()
   let fallbackHandler = [noSuffixHandler]
   // invalid DNs in non-strict mode are routed to the default handler
   const testDN = (typeof (req.dn) === 'string') ? DN.fromString(req.dn) : req.dn
+  assert.ok(testDN)
 
   for (let i = 0; i < keys.length; i++) {
     const suffix = keys[i]

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -257,6 +257,27 @@ tap.test('bind/unbind identity anonymous', function (t) {
   })
 })
 
+tap.test('does not crash on empty DN values', function (t) {
+  const server = ldap.createServer({
+    connectionRouter: function (c) {
+      server.newConnection(c)
+      server.emit('testconnection', c)
+    }
+  })
+
+  server.listen(t.context.sock, function () {
+    const client = ldap.createClient({ socketPath: t.context.sock })
+    server.once('testconnection', () => {
+      client.bind('', 'pw', function (err) {
+        t.ok(err, 'blank bind dn throws error')
+        client.unbind(function () {
+          server.close(() => t.end())
+        })
+      })
+    })
+  })
+})
+
 tap.test('bind/unbind identity user', function (t) {
   const server = ldap.createServer({
     connectionRouter: function (c) {


### PR DESCRIPTION
req.dn used to be parsed, now it's a string. This causes the server to crash because the assertion error cannot be trapped